### PR TITLE
sanitize colons from filenames

### DIFF
--- a/lib/gzr/modules/filehelper.rb
+++ b/lib/gzr/modules/filehelper.rb
@@ -49,7 +49,7 @@ module Gzr
           test_dir = base + Pathname.new(path_part)
           Dir.mkdir(test_dir) unless (test_dir.exist? && test_dir.directory?)
         end if p
-        file = Pathname.new(file_name.gsub('/',"\u{2215}")) if file_name
+        file = Pathname.new(file_name.gsub('/',"\u{2215}").gsub(':','')) if file_name
         file = p + file if p
         file = base + file if base
         f = File.open(file, "wt") if file


### PR DESCRIPTION
Remove colons from filenames so that `dashboard cat` and `look cat` are windows compatible when using the `--dir` flag.