### PR TITLE
fixes error when running dashboard import with --debug

### DIFF
--- a/lib/gzr/commands/dashboard/import.rb
+++ b/lib/gzr/commands/dashboard/import.rb
@@ -46,7 +46,7 @@ module Gzr
         end
 
         def execute(input: $stdin, output: $stdout)
-          say_warning("options: #{@options.inspect}", output) if @options[:debug]
+          say_warning("options: #{@options.inspect}", output: output) if @options[:debug]
           with_session("3.1") do
 
             @me ||= query_me("id")


### PR DESCRIPTION
Some folks were seeing this:
```
/Users/j0c05uo/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gazer-0.2.19/lib/gzr/modules/session.rb:40:in `say_warning': wrong number of arguments (given 2, expected 1) (ArgumentError)
from /Users/j0c05uo/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gazer-0.2.19/lib/gzr/commands/dashboard/import.rb:49:in `execute'
```
When running `gzr dashboard import` with `--debug`.

Seems like `output` was just provided as a regular argument rather than a keyword argument by accident.