### PR TITLE
Fixing Issue with Role rm Command

### DIFF
--- a/lib/gzr/commands/role/rm.rb
+++ b/lib/gzr/commands/role/rm.rb
@@ -38,7 +38,7 @@ module Gzr
         def execute(input: $stdin, output: $stdout)
           say_warning("options: #{@options.inspect}") if @options[:debug]
           with_session do
-            delete_role(@plan_id)
+            delete_role(@role_id)
           end
         end
       end


### PR DESCRIPTION
Fixing an issue with the command 'gzr role rm ROLE_ID' where ROLE_ID is the given ID of the role to remove/delete. The internal 'detele_role()' command was using an undefined variable instead of using the role_id passed in as the ID parameter. However, the internal 'delete_role()' command was not throwing any errors/exceptions when called with a null ID parameter, so it appears that the command was successful when it was not.