### PR TITLE
Update Tests to use Symbols for Operations

### DIFF
--- a/spec/unit/attribute/create_spec.rb
+++ b/spec/unit/attribute/create_spec.rb
@@ -25,78 +25,78 @@ require 'json'
 RSpec.describe Gzr::Commands::Attribute::Create do
   attrs = [
     {
-      :id=>1,
-      :name=>"attribute_1",
-      :label=>"Attribute 1",
-      :type=>"string",
-      :default_value=>nil,
-      :is_system=>true,
-      :is_permanent=>nil,
-      :value_is_hidden=>false,
-      :user_can_view=>true,
-      :user_can_edit=>true,
-      :hidden_value_domain_whitelist=>nil
+      :id => 1,
+      :name => "attribute_1",
+      :label => "Attribute 1",
+      :type => "string",
+      :default_value => nil,
+      :is_system => true,
+      :is_permanent => nil,
+      :value_is_hidden => false,
+      :user_can_view => true,
+      :user_can_edit => true,
+      :hidden_value_domain_whitelist => nil
     }.freeze,
     {
-      :id=>2,
-      :name=>"attribute_2",
-      :label=>"Attribute 2",
-      :type=>"number",
-      :default_value=>5,
-      :is_system=>false,
-      :is_permanent=>nil,
-      :value_is_hidden=>false,
-      :user_can_view=>true,
-      :user_can_edit=>true,
-      :hidden_value_domain_whitelist=>nil
+      :id => 2,
+      :name => "attribute_2",
+      :label => "Attribute 2",
+      :type => "number",
+      :default_value => 5,
+      :is_system => false,
+      :is_permanent => nil,
+      :value_is_hidden => false,
+      :user_can_view => true,
+      :user_can_edit => true,
+      :hidden_value_domain_whitelist => nil
     }.freeze,
     {
-      :id=>3,
-      :name=>"attribute_3",
-      :label=>"Attribute 3",
-      :type=>"string",
-      :default_value=>nil,
-      :is_system=>false,
-      :is_permanent=>nil,
-      :value_is_hidden=>false,
-      :user_can_view=>true,
-      :user_can_edit=>false,
-      :hidden_value_domain_whitelist=>nil
+      :id => 3,
+      :name => "attribute_3",
+      :label => "Attribute 3",
+      :type => "string",
+      :default_value => nil,
+      :is_system => false,
+      :is_permanent => nil,
+      :value_is_hidden => false,
+      :user_can_view => true,
+      :user_can_edit => false,
+      :hidden_value_domain_whitelist => nil
     }.freeze
   ]
 
   operations = {
-      "create_user_attribute"=>
-      {
-        :info=>{
-          :parameters=>[
-            {
-              :in=>"body",
-              :schema=>{ :$ref=>"#/definitions/UserAttribute" }
-            }
-          ]
-        }
-      },
-      "update_user_attribute"=>
-      {
-        :info=>{
-          :parameters=>[
-            {
-              "name": "user_attribute_id",
-              "in": "path",
-              "description": "Id of user attribute",
-              "required": true,
-              "type": "integer",
-              "format": "int64"
-            },
-            {
-              :in=>"body",
-              :schema=>{ :$ref=>"#/definitions/UserAttribute" }
-            }
-          ]
-        }
+    :create_user_attribute =>
+    {
+      :info => {
+        :parameters => [
+          {
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/UserAttribute" }
+          }
+        ]
       }
-    }.freeze
+    },
+    :update_user_attribute =>
+    {
+      :info => {
+        :parameters => [
+          {
+            "name": "user_attribute_id",
+            "in": "path",
+            "description": "Id of user attribute",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/UserAttribute" }
+          }
+        ]
+      }
+    }
+  }.freeze
 
   swagger = JSON.parse(<<-SWAGGER, {:symbolize_names => true}).freeze
     {

--- a/spec/unit/attribute/import_spec.rb
+++ b/spec/unit/attribute/import_spec.rb
@@ -24,78 +24,78 @@ require 'gzr/commands/attribute/import'
 RSpec.describe Gzr::Commands::Attribute::Import do
   attrs = [
     {
-      :id=>1,
-      :name=>"attribute_1",
-      :label=>"Attribute 1",
-      :type=>"string",
-      :default_value=>nil,
-      :is_system=>true,
-      :is_permanent=>nil,
-      :value_is_hidden=>false,
-      :user_can_view=>true,
-      :user_can_edit=>true,
-      :hidden_value_domain_whitelist=>nil
+      :id => 1,
+      :name => "attribute_1",
+      :label => "Attribute 1",
+      :type => "string",
+      :default_value => nil,
+      :is_system => true,
+      :is_permanent => nil,
+      :value_is_hidden => false,
+      :user_can_view => true,
+      :user_can_edit => true,
+      :hidden_value_domain_whitelist => nil
     }.freeze,
     {
-      :id=>2,
-      :name=>"attribute_2",
-      :label=>"Attribute 2",
-      :type=>"number",
-      :default_value=>5,
-      :is_system=>false,
-      :is_permanent=>nil,
-      :value_is_hidden=>false,
-      :user_can_view=>true,
-      :user_can_edit=>true,
-      :hidden_value_domain_whitelist=>nil
+      :id => 2,
+      :name => "attribute_2",
+      :label => "Attribute 2",
+      :type => "number",
+      :default_value => 5,
+      :is_system => false,
+      :is_permanent => nil,
+      :value_is_hidden => false,
+      :user_can_view => true,
+      :user_can_edit => true,
+      :hidden_value_domain_whitelist => nil
     }.freeze,
     {
-      :id=>3,
-      :name=>"attribute_3",
-      :label=>"Attribute 3",
-      :type=>"string",
-      :default_value=>nil,
-      :is_system=>false,
-      :is_permanent=>nil,
-      :value_is_hidden=>false,
-      :user_can_view=>true,
-      :user_can_edit=>false,
-      :hidden_value_domain_whitelist=>nil
+      :id => 3,
+      :name => "attribute_3",
+      :label => "Attribute 3",
+      :type => "string",
+      :default_value => nil,
+      :is_system => false,
+      :is_permanent => nil,
+      :value_is_hidden => false,
+      :user_can_view => true,
+      :user_can_edit => false,
+      :hidden_value_domain_whitelist => nil
     }.freeze
   ]
 
   operations = {
-      "create_user_attribute"=>
-      {
-        :info=>{
-          :parameters=>[
-            {
-              :in=>"body",
-              :schema=>{ :$ref=>"#/definitions/UserAttribute" }
-            }
-          ]
-        }
-      },
-      "update_user_attribute"=>
-      {
-        :info=>{
-          :parameters=>[
-            {
-              "name": "user_attribute_id",
-              "in": "path",
-              "description": "Id of user attribute",
-              "required": true,
-              "type": "integer",
-              "format": "int64"
-            },
-            {
-              :in=>"body",
-              :schema=>{ :$ref=>"#/definitions/UserAttribute" }
-            }
-          ]
-        }
+    :create_user_attribute =>
+    {
+      :info => {
+        :parameters => [
+          {
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/UserAttribute" }
+          }
+        ]
       }
-    }.freeze
+    },
+    :update_user_attribute =>
+    {
+      :info => {
+        :parameters => [
+          {
+            "name": "user_attribute_id",
+            "in": "path",
+            "description": "Id of user attribute",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/UserAttribute" }
+          }
+        ]
+      }
+    }
+  }.freeze
 
   swagger = JSON.parse(<<-SWAGGER, {:symbolize_names => true}).freeze
     {

--- a/spec/unit/dashboard/import_spec.rb
+++ b/spec/unit/dashboard/import_spec.rb
@@ -25,48 +25,48 @@ RSpec.describe Gzr::Commands::Dashboard::Import do
   me_response_doc = { :id=>1000, :first_name=>"John", :last_name=>"Jones", :email=>"jjones@example.com" }.freeze
 
   dash_response_doc = {
-      :id=>500,
-      :title=>"Original Dash",
-      :description=> "Description of the Dash",
-      :slug=> "123xyz",
-      :space_id=> 1,
-      :deleted=> false,
-      :dashboard_filters=>[],
-      :dashboard_elements=>[],
-      :dashboard_layouts=>[]
-    }.freeze
+    :id => 500,
+    :title => "Original Dash",
+    :description => "Description of the Dash",
+    :slug => "123xyz",
+    :space_id => 1,
+    :deleted => false,
+    :dashboard_filters => [],
+    :dashboard_elements => [],
+    :dashboard_layouts => []
+  }.freeze
 
   operations = {
-      "create_dashboard"=>
-      {
-        :info=>{
-          :parameters=>[
-            {
-              :in=>"body",
-              :schema=>{ :$ref=>"#/definitions/Dashboard" }
-            }
-          ]
-        }
-      },
-      "update_dashboard"=>
-      {
-        :info=>{
-          :parameters=>[
-            {
-              "name": "dashboard_id",
-              "in": "path",
-              "description": "Id of dashboard",
-              "required": true,
-              "type": "string"
-            },
-            {
-              :in=>"body",
-              :schema=>{ :$ref=>"#/definitions/Dashboard" }
-            }
-          ]
-        }
+    :create_dashboard =>
+    {
+      :info => {
+        :parameters => [
+          {
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/Dashboard" }
+          }
+        ]
       }
-    }.freeze
+    },
+    :update_dashboard =>
+    {
+      :info => {
+        :parameters => [
+          {
+            "name": "dashboard_id",
+            "in": "path",
+            "description": "Id of dashboard",
+            "required": true,
+            "type": "string"
+          },
+          {
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/Dashboard" }
+          }
+        ]
+      }
+    }
+  }.freeze
 
   swagger = JSON.parse(<<-SWAGGER, {:symbolize_names => true}).freeze
     { "definitions": {

--- a/spec/unit/dashboard/mv_spec.rb
+++ b/spec/unit/dashboard/mv_spec.rb
@@ -23,37 +23,37 @@ require 'gzr/commands/dashboard/mv'
 
 RSpec.describe Gzr::Commands::Dashboard::Mv do
   dash_response_doc = {
-      :id=>500,
-      :title=>"Original Dash",
-      :description=> "Description of the Dash",
-      :slug=> "123xyz",
-      :space_id=> 1,
-      :deleted=> false,
-      :dashboard_filters=>[],
-      :dashboard_elements=>[],
-      :dashboard_layouts=>[]
-    }.freeze
+    :id => 500,
+    :title => "Original Dash",
+    :description => "Description of the Dash",
+    :slug => "123xyz",
+    :space_id => 1,
+    :deleted => false,
+    :dashboard_filters => [],
+    :dashboard_elements => [],
+    :dashboard_layouts => []
+  }.freeze
 
   operations = {
-      "update_dashboard"=>
-      {
-        :info=>{
-          :parameters=>[
-            {
-              "name": "dashboard_id",
-              "in": "path",
-              "description": "Id of dashboard",
-              "required": true,
-              "type": "string"
-            },
-            {
-              :in=>"body",
-              :schema=>{ :$ref=>"#/definitions/Dashboard" }
-            }
-          ]
-        }
+    :update_dashboard =>
+    {
+      :info => {
+        :parameters => [
+          {
+            "name": "dashboard_id",
+            "in": "path",
+            "description": "Id of dashboard",
+            "required": true,
+            "type": "string"
+          },
+          {
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/Dashboard" }
+          }
+        ]
       }
-    }.freeze
+    }
+  }.freeze
 
   define_method :mock_sdk do |block_hash={}|
     mock_sdk = Object.new

--- a/spec/unit/look/import_spec.rb
+++ b/spec/unit/look/import_spec.rb
@@ -27,39 +27,39 @@ RSpec.describe Gzr::Commands::Look::Import do
   query_response_doc = { :id=>555 }.freeze
 
   look_response_doc = {
-    :id=>31415,
-    :title=>"Daily Profit",
-    :description=>"Total profit by day for the last 100 days",
-    :query_id=>555,
-    :user_id=>1000,
-    :space_id=>1,
-    :slug=>"123xyz"
+    :id => 31415,
+    :title => "Daily Profit",
+    :description => "Total profit by day for the last 100 days",
+    :query_id => 555,
+    :user_id => 1000,
+    :space_id => 1,
+    :slug => "123xyz"
   }.freeze
 
   operations = {
-    "create_query"=> {
-      :info=>{
-        :parameters=>[
+    :create_query => {
+      :info => {
+        :parameters => [
           {
-            :in=>"body",
-            :schema=>{ :$ref=>"#/definitions/Query" }
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/Query" }
           }
         ]
       }
     },
-    "create_look"=>{
-      :info=>{
-        :parameters=>[
+    :create_look => {
+      :info => {
+        :parameters => [
           {
-            :in=>"body",
-            :schema=>{ :$ref=>"#/definitions/Look" }
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/Look" }
           }
         ]
       }
     },
-    "update_look"=>{
-      :info=>{
-        :parameters=>[
+    :update_look => {
+      :info => {
+        :parameters => [
           {
               "name": "look_id",
               "in": "path",
@@ -69,8 +69,8 @@ RSpec.describe Gzr::Commands::Look::Import do
               "format": "int64"
           },
           {
-            :in=>"body",
-            :schema=>{ :$ref=>"#/definitions/Look" }
+            :in => "body",
+            :schema => { :$ref=>"#/definitions/Look" }
           }
         ]
       }


### PR DESCRIPTION
Updating tests to use symbols for operations instead of their string equivalents.