### PR TITLE
Use environment variables for login to simplify CI

### DIFF
--- a/gzr.gemspec
+++ b/gzr.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.version       = Gzr::VERSION
   spec.authors       = ["Mike DeAngelo"]
-  spec.email         = ["deangelo@looker.com"]
+  spec.email         = ["drstrangelove@google.com"]
 
   spec.summary       = %q{Command line tool to manage the content of a Looker instance.}
   spec.description   = %q{Command line tool to manage the content of a Looker instance.}

--- a/lib/gzr/cli.rb
+++ b/lib/gzr/cli.rb
@@ -44,7 +44,6 @@ module Gzr
     class_option :width, type: :numeric, default: nil, desc: 'Width of rendering for tables'
     class_option :persistent, type: :boolean, default: false, desc: 'Use persistent connection to communicate with host'
 
-
     # Error raised by this runner
     Error = Class.new(StandardError)
 


### PR DESCRIPTION
The CI environment works more easily when environment variables are used for login rather than .netrc.