### PR TITLE
fix: Added alias for folder command to point to space.

### DIFF
--- a/lib/gzr/cli.rb
+++ b/lib/gzr/cli.rb
@@ -57,6 +57,7 @@ module Gzr
       puts "v#{Gzr::VERSION}"
     end
     map %w(--version -v) => :version
+    map folder: :space  # Alias folder command to space
 
     require_relative 'commands/attribute'
     register Gzr::Commands::Attribute, 'attribute', 'attribute [SUBCOMMAND]', 'Command description...'


### PR DESCRIPTION
For convenience and to facilitate a future update to Looker API v4.0 which uses ‘folder’ in place of the depreciated ‘space.’