### PR TITLE
fix: for dashboard cat with --plans 

### DIFF
--- a/lib/gzr/modules/dashboard.rb
+++ b/lib/gzr/modules/dashboard.rb
@@ -250,7 +250,7 @@ module Gzr
           data[:dashboard_elements][i][:merge_result] = merge_result
         end
       end
-      data[:scheduled_plans] = query_scheduled_plans_for_dashboard(@dashboard_id,"all")&.to_attrs if @options[:plans]
+      data[:scheduled_plans] = query_scheduled_plans_for_dashboard(@dashboard_id,"all") if @options[:plans]
       data
     end
   end

--- a/lib/gzr/modules/plan.rb
+++ b/lib/gzr/modules/plan.rb
@@ -76,6 +76,7 @@ module Gzr
         say_error e.message
         raise
       end
+      data.map! {|plan| plan.to_attrs}
       data
     end
     


### PR DESCRIPTION
For issue #131 
Changes the return data to convert the array items to hash before returning.