### PR TITLE
fix: add require statement to prevent `uninitialized constant` errors

### DIFF
--- a/lib/gzr/modules/filehelper.rb
+++ b/lib/gzr/modules/filehelper.rb
@@ -23,6 +23,7 @@
 
 require 'pathname'
 require 'rubygems/package'
+require 'stringio'
 
 module Gzr
   module FileHelper


### PR DESCRIPTION
Added require statement to prevent `uninitialized constant` errors when calling StringIO, a problem that occurs when using ruby v3.