### PR TITLE
feat: Add --trim option for dashboard cat, look cat, and folder export commands

### DIFF
--- a/lib/gzr/commands/dashboard.rb
+++ b/lib/gzr/commands/dashboard.rb
@@ -53,7 +53,9 @@ module Gzr
       method_option :transform,  type: :string,
                            desc: 'Fully-qualified path to a JSON file describing the transformations to apply'
       method_option :simple_filename, type: :boolean,
-                    desc: 'Use simple filename for output (Dashboard_<id>.json)'
+                           desc: 'Use simple filename for output (Dashboard_<id>.json)'
+      method_option :trim, type: :boolean,
+                           desc: 'Trim output to minimal set of fields for later import'
       def cat(dashboard_id)
         if options[:help]
           invoke :help, ['cat']

--- a/lib/gzr/commands/dashboard/cat.rb
+++ b/lib/gzr/commands/dashboard/cat.rb
@@ -44,6 +44,7 @@ module Gzr
           say_warning("options: #{@options.inspect}") if @options[:debug]
           with_session do
             data = cat_dashboard(@dashboard_id)
+            data = trim_dashboard(data) if @options[:trim]
 
             replacements = {}
             if @options[:transform]

--- a/lib/gzr/commands/folder.rb
+++ b/lib/gzr/commands/folder.rb
@@ -66,6 +66,8 @@ module Gzr
                            desc: 'Display usage information'
       method_option :plans,  type: :boolean,
                            desc: 'Include scheduled plans'
+      method_option :trim,  type: :boolean,
+                           desc: 'Trim output to minimal set of fields for later import'
       method_option :dir, type: :string, default: '.',
                            desc: 'Directory to store output tree'
       method_option :tar, type: :string,

--- a/lib/gzr/commands/folder/export.rb
+++ b/lib/gzr/commands/folder/export.rb
@@ -99,12 +99,14 @@ module Gzr
           end
           folder[:looks].each do |l|
             look = cat_look(l[:id])
+            look = trim_look(look) if @options[:trim]
             write_file("Look_#{look[:id]}_#{look[:title]}.json", base, path) do |f|
               f.write JSON.pretty_generate(look)
             end
           end
           folder[:dashboards].each do |d|
             data = cat_dashboard(d[:id])
+            data = trim_dashboard(data) if @options[:trim]
             write_file("Dashboard_#{data[:id]}_#{data[:title]}.json", base, path) do |f|
               f.write JSON.pretty_generate(data)
             end

--- a/lib/gzr/commands/look.rb
+++ b/lib/gzr/commands/look.rb
@@ -84,6 +84,8 @@ module Gzr
                            desc: 'Include scheduled plans'
       method_option :simple_filename,  type: :boolean,
                            desc: 'Use simple filename for output (Look_<id>.json)'
+      method_option :trim, type: :boolean,
+                           desc: 'Trim output to minimal set of fields for later import'
       def cat(look_id)
         if options[:help]
           invoke :help, ['cat']

--- a/lib/gzr/commands/look/cat.rb
+++ b/lib/gzr/commands/look/cat.rb
@@ -43,6 +43,7 @@ module Gzr
           say_warning("options: #{@options.inspect}") if @options[:debug]
           with_session do
             data = cat_look(@look_id)
+            data = trim_look(data) if @options[:trim]
             file_name = if @options[:dir]
                           @options[:simple_filename] ? "Look_#{data[:id]}.json" : "Look_#{data[:id]}_#{data[:title]}.json"
                         else

--- a/lib/gzr/modules/dashboard.rb
+++ b/lib/gzr/modules/dashboard.rb
@@ -266,5 +266,66 @@ module Gzr
       data[:scheduled_plans] = query_scheduled_plans_for_dashboard(@dashboard_id,"all") if @options[:plans]
       data
     end
+
+    def trim_dashboard(data)
+      trimmed = data.select do |k,v|
+        (keys_to_keep('update_dashboard') + [:id,:dashboard_elements,:dashboard_filters,:dashboard_layouts]).include? k
+      end
+
+      trimmed[:dashboard_elements] = data[:dashboard_elements].map do |de|
+        new_de = de.select do |k,v|
+          (keys_to_keep('update_dashboard_element') + [:id,:look,:query,:merge_result]).include? k
+        end
+        if de[:look]
+          new_de[:look] = de[:look].select do |k,v|
+            (keys_to_keep('update_look') + [:id,:query]).include? k
+          end
+          if de[:look][:query]
+            new_de[:look][:query] = de[:look][:query].select do |k,v|
+              (keys_to_keep('create_query') + [:id]).include? k
+            end
+          end
+        end
+        if de[:query]
+          new_de[:query] = de[:query].select do |k,v|
+            (keys_to_keep('create_query') + [:id]).include? k
+          end
+        end
+        if de[:merge_result]
+          new_de[:merge_result] = de[:merge_result].select do |k,v|
+            (keys_to_keep('update_merge_query') + [:id]).include? k
+          end
+          new_de[:merge_result][:source_queries] = de[:merge_result][:source_queries].map do |sq|
+            sq.select do |k,v|
+              (keys_to_keep('create_query') + [:id]).include? k
+            end
+          end
+        end
+        new_de
+      end
+
+      trimmed[:dashboard_filters] = data[:dashboard_filters].map do |df|
+        new_df = df.select do |k,v|
+          keys_to_keep('update_dashboard_filter').include? k
+        end
+        new_df
+      end
+
+      trimmed[:dashboard_layouts] = data[:dashboard_layouts].map do |dl|
+        new_dl = dl.select do |k,v|
+          (keys_to_keep('update_dashboard_layout') + [:id]).include? k
+        end
+        if dl[:dashboard_layout_components]
+          new_dl[:dashboard_layout_components] = dl[:dashboard_layout_components].map do |dlc|
+            dlc.select do |k,v|
+              (keys_to_keep('update_dashboard_layout_component') + [:id]).include? k
+            end
+          end
+        end
+        new_dl
+      end
+
+      trimmed
+    end
   end
 end

--- a/lib/gzr/modules/dashboard.rb
+++ b/lib/gzr/modules/dashboard.rb
@@ -269,7 +269,7 @@ module Gzr
 
     def trim_dashboard(data)
       trimmed = data.select do |k,v|
-        (keys_to_keep('update_dashboard') + [:id,:dashboard_elements,:dashboard_filters,:dashboard_layouts]).include? k
+        (keys_to_keep('update_dashboard') + [:id,:dashboard_elements,:dashboard_filters,:dashboard_layouts,:scheduled_plans]).include? k
       end
 
       trimmed[:dashboard_elements] = data[:dashboard_elements].map do |de|
@@ -324,6 +324,12 @@ module Gzr
         end
         new_dl
       end
+
+      trimmed[:scheduled_plans] = data[:scheduled_plans].map do |sp|
+        sp.select do |k,v|
+          (keys_to_keep('create_scheduled_plan') + [:id]).include? k
+        end
+      end if data[:scheduled_plans]
 
       trimmed
     end

--- a/lib/gzr/modules/look.rb
+++ b/lib/gzr/modules/look.rb
@@ -198,8 +198,25 @@ module Gzr
         end
       end
 
-      data[:scheduled_plans] = query_scheduled_plans_for_look(@look_id,"all")&.to_attrs if @options[:plans]
+      data[:scheduled_plans] = query_scheduled_plans_for_look(@look_id,"all").map { |e| e.to_attrs }  if @options[:plans]
       data
+    end
+
+    def trim_look(data)
+      trimmed = data.select do |k,v|
+        (keys_to_keep('update_look') + [:id,:query]).include? k
+      end
+      trimmed[:query] = data[:query].select do |k,v|
+        (keys_to_keep('create_query') + [:id]).include? k
+      end
+
+      trimmed[:scheduled_plans] = data[:scheduled_plans].map do |sp|
+        sp.select do |k,v|
+          (keys_to_keep('create_scheduled_plan') + [:id]).include? k
+        end
+      end if data[:scheduled_plans]
+
+      trimmed
     end
   end
 end

--- a/spec/integration/dashboard/cat_spec.rb
+++ b/spec/integration/dashboard/cat_spec.rb
@@ -32,6 +32,7 @@ Options:
       [--plans], [--no-plans]                      # Include scheduled plans
       [--transform=TRANSFORM]                      # Fully-qualified path to a JSON file describing the transformations to apply
       [--simple-filename], [--no-simple-filename]  # Use simple filename for output (Dashboard_<id>.json)
+      [--trim], [--no-trim]                        # Trim output to minimal set of fields for later import
 
 Output the JSON representation of a dashboard to the screen or a file
     OUT

--- a/spec/integration/folder/export_spec.rb
+++ b/spec/integration/folder/export_spec.rb
@@ -29,6 +29,7 @@ Usage:
 Options:
   -h, [--help], [--no-help]    # Display usage information
       [--plans], [--no-plans]  # Include scheduled plans
+      [--trim], [--no-trim]    # Trim output to minimal set of fields for later import
       [--dir=DIR]              # Directory to store output tree
                                # Default: .
       [--tar=TAR]              # Tar file to store output

--- a/spec/integration/look/cat_spec.rb
+++ b/spec/integration/look/cat_spec.rb
@@ -31,6 +31,7 @@ Options:
       [--dir=DIR]                                  # Directory to store output file
       [--plans], [--no-plans]                      # Include scheduled plans
       [--simple-filename], [--no-simple-filename]  # Use simple filename for output (Look_<id>.json)
+      [--trim], [--no-trim]                        # Trim output to minimal set of fields for later import
 
 Output the JSON representation of a look to the screen or a file
     OUT


### PR DESCRIPTION
The `--trim` flag will take the long output json documents and reduce them in size to only the information that is needed to do an import later on. The read-only fields are eliminated. That makes the files easier to compare. The output of diff is more useful.