### PR TITLE
feat: Alerts management through gazer

### DIFF
--- a/lib/gzr/cli.rb
+++ b/lib/gzr/cli.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/cli.rb
+++ b/lib/gzr/cli.rb
@@ -58,6 +58,9 @@ module Gzr
     map %w(--version -v) => :version
     map space: :folder  # Alias space command to folder
 
+    require_relative 'commands/alert'
+    register Gzr::Commands::Alert, 'alert', 'alert [SUBCOMMAND]', 'Command description...'
+
     require_relative 'commands/attribute'
     register Gzr::Commands::Attribute, 'attribute', 'attribute [SUBCOMMAND]', 'Command description...'
 

--- a/lib/gzr/command.rb
+++ b/lib/gzr/command.rb
@@ -1,6 +1,6 @@
 # The MIT icense (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/command.rb
+++ b/lib/gzr/command.rb
@@ -52,6 +52,18 @@ module Gzr
       )
     end
 
+    def get_user_by_id(user_id, req=nil)
+      user = nil
+      begin
+        user = @sdk.user(user_id, req)
+      rescue LookerSDK::Error => e
+        say_error "Error querying get_user_by_id(#{user_id})"
+        say_error e
+        raise
+      end
+      user
+    end
+
     def query(query_id)
       data = nil
       begin

--- a/lib/gzr/command.rb
+++ b/lib/gzr/command.rb
@@ -401,6 +401,66 @@ module Gzr
       parts.join('&.')
     end
 
+
+    # This version of field names yields an expression that can be evaluated against a hash structure
+    # like this one...
+    #
+    # data&.fetch(:a,nil)
+    # val1
+    # data&.fetch(:b,nil)
+    # val2
+    # data&.fetch(:c,nil)&.fetch(:d,nil)
+    # val3
+    # data&.fetch(:c,nil)&.fetch(:e,nil)&.fetch(:f,nil)
+    # val4
+    # data&.fetch(:c,nil)&.fetch(:e,nil)&.fetch(:g,nil)
+    # val5
+    # data&.fetch(:h,nil)
+    # val6
+    #
+    # data =
+    # {
+    #   a: "val",
+    #   b: "val",
+    #   c: {
+    #     d: "val",
+    #     e: {
+    #       f: "val",
+    #       g: "val"
+    #     }
+    #   },
+    #   h: "val"
+    # }
+    #
+    # field_names_hash(fields).each do |field|
+    #   puts "data#{field}"
+    #   puts eval "data#{field}"
+    # end
+
+    def field_names_hash(opt_fields)
+      fields = []
+      token_stack = []
+      last_token = false
+      tokens = opt_fields.split /(\(|,|\))/
+      tokens << nil
+      tokens.each do |t|
+        if t == '(' then
+          token_stack.push(last_token)
+        elsif t.nil? || t == ',' then
+          fields << "&.fetch(:#{(token_stack + [last_token]).join(',nil)&.fetch(:')},nil)" if last_token
+        elsif t.empty? then
+          next
+        elsif t == ')' then
+          fields << "&.fetch(:#{(token_stack + [last_token]).join(',nil)&.fetch(:')},nil)" if last_token
+          token_stack.pop
+          last_token = false
+        else
+          last_token = t
+        end
+      end
+      fields
+    end
+
     ##
     # This method will accept two arrays, a and b, and create a third array
     # like [ [a[0],b[0]], [a[1],b[1]], [a[2],b[2]], ...].

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -88,6 +88,30 @@ module Gzr
           Gzr::Commands::Alert::Unfollow.new(alert_id,options).execute
         end
       end
+
+      desc 'enable ALERT_ID', 'Enable the alert given by ALERT_ID'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def enable(alert_id)
+        if options[:help]
+          invoke :help, ['enable']
+        else
+          require_relative 'alert/enable'
+          Gzr::Commands::Alert::Enable.new(alert_id,options).execute
+        end
+      end
+
+      desc 'disable ALERT_ID REASON', 'Disable the alert given by ALERT_ID'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def disable(alert_id,reason)
+        if options[:help]
+          invoke :help, ['disable']
+        else
+          require_relative 'alert/disable'
+          Gzr::Commands::Alert::Disable.new(alert_id,reason,options).execute
+        end
+      end
     end
   end
 end

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -64,6 +64,30 @@ module Gzr
           Gzr::Commands::Alert::Cat.new(alert_id,options).execute
         end
       end
+
+      desc 'follow ALERT_ID', 'Start following the alert given by ALERT_ID'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def follow_alert(alert_id)
+        if options[:help]
+          invoke :help, ['follow']
+        else
+          require_relative 'alert/follow'
+          Gzr::Commands::Alert::Follow.new(alert_id,options).execute
+        end
+      end
+
+      desc 'unfollow ALERT_ID', 'Stop following the alert given by ALERT_ID'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def unfollow_alert(alert_id)
+        if options[:help]
+          invoke :help, ['unfollow']
+        else
+          require_relative 'alert/unfollow'
+          Gzr::Commands::Alert::Unfollow.new(alert_id,options).execute
+        end
+      end
     end
   end
 end

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -124,6 +124,19 @@ module Gzr
           Gzr::Commands::Alert::Threshold.new(alert_id,threshold,options).execute
         end
       end
+
+      desc 'rm ALERT_ID', 'Delete the alert given by ALERT_ID'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def rm(alert_id)
+        if options[:help]
+          invoke :help, ['delete']
+        else
+          require_relative 'alert/delete'
+          Gzr::Commands::Alert::Delete.new(alert_id,options).execute
+        end
+      end
+
     end
   end
 end

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -137,6 +137,18 @@ module Gzr
         end
       end
 
+      desc 'chown ALERT_ID OWNER_ID', 'Change the owner of the alert given by ALERT_ID to OWNER_ID'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def chown(alert_id, owner_id)
+        if options[:help]
+          invoke :help, ['chown']
+        else
+          require_relative 'alert/chown'
+          Gzr::Commands::Alert::Chown.new(alert_id,owner_id,options).execute
+        end
+      end
+
     end
   end
 end

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -34,9 +34,9 @@ module Gzr
                            desc: 'Display usage information'
       method_option :fields, type: :string, default: 'id,field(title,name),comparison_type,threshold,cron,custom_title,dashboard_element_id,description',
                            desc: 'Fields to display'
-      method_option :disabled, type: :boolean, default: false,
+      method_option :disabled, type: :boolean, default: nil,
                            desc: 'return disabled alerts'
-      method_option :all, type: :boolean, default: false,
+      method_option :all, type: :boolean, default: nil,
                            desc: 'return alerts from all users (must be admin)'
       method_option :plain, type: :boolean, default: false,
                            desc: 'print without any extra formatting'

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -149,6 +149,38 @@ module Gzr
         end
       end
 
+      desc 'notifications', 'Get notifications'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :plain, type: :boolean, default: false,
+                           desc: 'print without any extra formatting'
+      method_option :csv, type: :boolean, default: false,
+                           desc: 'output in csv format per RFC4180'
+      def notifications(*)
+        if options[:help]
+          invoke :help, ['notifications']
+        else
+          require_relative 'alert/notifications'
+          Gzr::Commands::Alert::Notifications.new(options).execute
+        end
+      end
+
+      desc 'read NOTIFICATION_ID', 'Read notification id'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :plain, type: :boolean, default: false,
+                           desc: 'print without any extra formatting'
+      method_option :csv, type: :boolean, default: false,
+                           desc: 'output in csv format per RFC4180'
+      def read(notification_id)
+        if options[:help]
+          invoke :help, ['read']
+        else
+          require_relative 'alert/read'
+          Gzr::Commands::Alert::Read.new(notification_id,options).execute
+        end
+      end
+
     end
   end
 end

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -112,6 +112,18 @@ module Gzr
           Gzr::Commands::Alert::Disable.new(alert_id,reason,options).execute
         end
       end
+
+      desc 'threshold ALERT_ID THRESHOLD', 'Change the threshold of the alert given by ALERT_ID'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def threshold(alert_id,threshold)
+        if options[:help]
+          invoke :help, ['threshold']
+        else
+          require_relative 'alert/threshold'
+          Gzr::Commands::Alert::Threshold.new(alert_id,threshold,options).execute
+        end
+      end
     end
   end
 end

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -1,0 +1,65 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require 'thor'
+
+module Gzr
+  module Commands
+    class Alert < Thor
+
+      namespace :alert
+
+      desc 'ls', 'list alerts'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :fields, type: :string, default: 'id,field(title,name),comparison_type,threshold,cron,custom_title,dashboard_element_id,description',
+                           desc: 'Fields to display'
+      method_option :plain, type: :boolean, default: false,
+                           desc: 'print without any extra formatting'
+      method_option :csv, type: :boolean, default: false,
+                           desc: 'output in csv format per RFC4180'
+      def ls(*)
+        if options[:help]
+          invoke :help, ['ls']
+        else
+          require_relative 'alert/ls'
+          Gzr::Commands::Alert::Ls.new(options).execute
+        end
+      end
+
+      desc 'cat ALERT_ID', 'Output json information about an alert to screen or file'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :dir,  type: :string,
+                           desc: 'Directory to store output file'
+      def cat(alert_id)
+        if options[:help]
+          invoke :help, ['cat']
+        else
+          require_relative 'alert/cat'
+          Gzr::Commands::Alert::Cat.new(alert_id,options).execute
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -34,6 +34,10 @@ module Gzr
                            desc: 'Display usage information'
       method_option :fields, type: :string, default: 'id,field(title,name),comparison_type,threshold,cron,custom_title,dashboard_element_id,description',
                            desc: 'Fields to display'
+      method_option :disabled, type: :boolean, default: false,
+                           desc: 'return disabled alerts'
+      method_option :all, type: :boolean, default: false,
+                           desc: 'return alerts from all users (must be admin)'
       method_option :plain, type: :boolean, default: false,
                            desc: 'print without any extra formatting'
       method_option :csv, type: :boolean, default: false,

--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -181,6 +181,20 @@ module Gzr
         end
       end
 
+      desc 'import FILE [DASHBOARD_ELEMENT_ID]', 'Import an alert from a file'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :plain, type: :boolean,
+                           desc: 'Provide minimal response information'
+      def import(file,dashboard_element_id=nil)
+        if options[:help]
+          invoke :help, ['import']
+        else
+          require_relative 'alert/import'
+          Gzr::Commands::Alert::Import.new(file, dashboard_element_id, options).execute
+        end
+      end
+
     end
   end
 end

--- a/lib/gzr/commands/alert/cat.rb
+++ b/lib/gzr/commands/alert/cat.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/cat.rb
+++ b/lib/gzr/commands/alert/cat.rb
@@ -1,0 +1,52 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+require_relative '../../modules/filehelper'
+
+module Gzr
+  module Commands
+    class Alert
+      class Cat < Gzr::Command
+        include Gzr::Alert
+        include Gzr::FileHelper
+        def initialize(alert_id,options)
+          super()
+          @alert_id = alert_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+            alert = get_alert(@alert_id)
+            write_file(@options[:dir] ? "Alert_#{alert.id}_#{alert.field.name}.json" : nil, @options[:dir],nil, output) do |f|
+              f.puts JSON.pretty_generate(alert.to_attrs)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/chown.rb
+++ b/lib/gzr/commands/alert/chown.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/chown.rb
+++ b/lib/gzr/commands/alert/chown.rb
@@ -1,0 +1,48 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+
+module Gzr
+  module Commands
+    class Alert
+      class Chown < Gzr::Command
+        include Gzr::Alert
+        def initialize(alert_id,owner_id,options)
+          super()
+          @alert_id = alert_id
+          @owner_id = owner_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+           update_alert_field(@alert_id, owner_id: @owner_id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/delete.rb
+++ b/lib/gzr/commands/alert/delete.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/delete.rb
+++ b/lib/gzr/commands/alert/delete.rb
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+
+module Gzr
+  module Commands
+    class Alert
+      class Delete < Gzr::Command
+        include Gzr::Alert
+        def initialize(alert_id,options)
+          super()
+          @alert_id = alert_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+           delete_alert(@alert_id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/disable.rb
+++ b/lib/gzr/commands/alert/disable.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/disable.rb
+++ b/lib/gzr/commands/alert/disable.rb
@@ -1,0 +1,48 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+
+module Gzr
+  module Commands
+    class Alert
+      class Disable < Gzr::Command
+        include Gzr::Alert
+        def initialize(alert_id, disabled_reason, options)
+          super()
+          @alert_id = alert_id
+          @disabled_reason = disabled_reason
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+           update_alert_field(@alert_id, is_disabled: true, disabled_reason: @disabled_reason)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/enable.rb
+++ b/lib/gzr/commands/alert/enable.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/enable.rb
+++ b/lib/gzr/commands/alert/enable.rb
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+
+module Gzr
+  module Commands
+    class Alert
+      class Enable < Gzr::Command
+        include Gzr::Alert
+        def initialize(alert_id,options)
+          super()
+          @alert_id = alert_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+           update_alert_field(@alert_id, is_disabled: false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/follow.rb
+++ b/lib/gzr/commands/alert/follow.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/follow.rb
+++ b/lib/gzr/commands/alert/follow.rb
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+
+module Gzr
+  module Commands
+    class Alert
+      class Follow < Gzr::Command
+        include Gzr::Alert
+        def initialize(alert_id,options)
+          super()
+          @alert_id = alert_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+           follow_alert(@alert_id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/import.rb
+++ b/lib/gzr/commands/alert/import.rb
@@ -1,0 +1,65 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../../gzr'
+require_relative '../../command'
+require_relative '../../modules/alert'
+require_relative '../../modules/user'
+require_relative '../../modules/filehelper'
+
+module Gzr
+  module Commands
+    class Alert
+      class Import < Gzr::Command
+        include Gzr::Alert
+        include Gzr::User
+        include Gzr::FileHelper
+        def initialize(file, dashboard_element_id, options)
+          super()
+          @file = file
+          @dashboard_element_id = dashboard_element_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning("options: #{@options.inspect}", output: output) if @options[:debug]
+          with_session do
+
+            @me ||= query_me("id")
+
+            read_file(@file) do |data|
+              data.select! do |k,v|
+                keys_to_keep('create_alert').include? k
+              end
+              data[:owner_id] = @me[:id]
+              data[:dashboard_element_id] = @dashboard_element_id if @dashboard_element_id
+              alert = create_alert(data)
+              output.puts "Imported alert #{alert[:id]}" unless @options[:plain]
+              output.puts alert[:id] if @options[:plain]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/import.rb
+++ b/lib/gzr/commands/alert/import.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/ls.rb
+++ b/lib/gzr/commands/alert/ls.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2018 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/ls.rb
+++ b/lib/gzr/commands/alert/ls.rb
@@ -38,8 +38,7 @@ module Gzr
         def execute(input: $stdin, output: $stdout)
           say_warning(@options) if @options[:debug]
           with_session do
-            f = @options[:fields]
-            data = search_alerts(f)
+            data = search_alerts(fields: @options[:fields], disabled: @options[:disabled], all_owners: @options[:all])
             begin
               say_ok "No alerts found"
               return nil

--- a/lib/gzr/commands/alert/ls.rb
+++ b/lib/gzr/commands/alert/ls.rb
@@ -38,7 +38,11 @@ module Gzr
         def execute(input: $stdin, output: $stdout)
           say_warning(@options) if @options[:debug]
           with_session do
-            data = search_alerts(fields: @options[:fields], disabled: @options[:disabled], all_owners: @options[:all])
+            req = {}
+            req[:fields] = @options[:fields] unless @options[:fields].nil?
+            req[:disabled] = @options[:disabled] unless @options[:disabled].nil?
+            req[:all_owners] = @options[:all] unless @options[:all].nil?
+            data = search_alerts(**req)
             begin
               say_ok "No alerts found"
               return nil

--- a/lib/gzr/commands/alert/ls.rb
+++ b/lib/gzr/commands/alert/ls.rb
@@ -1,0 +1,73 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+require 'tty-table'
+
+module Gzr
+  module Commands
+    class Alert
+      class Ls < Gzr::Command
+        include Gzr::Alert
+        def initialize(options)
+          super()
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+            f = @options[:fields]
+            data = search_alerts(f)
+            begin
+              say_ok "No alerts found"
+              return nil
+            end unless data && data.length > 0
+
+            table_hash = Hash.new
+            fields = field_names(@options[:fields])
+            table_hash[:header] = fields unless @options[:plain]
+            expressions = fields.collect { |fn| field_expression(fn) }
+            table_hash[:rows] = data.map do |row|
+              expressions.collect do |e|
+                eval "row.#{e}"
+              end
+            end
+            table = TTY::Table.new(table_hash)
+            alignments = fields.collect do |k|
+              (k =~ /id$/) ? :right : :left
+            end
+            begin
+              if @options[:csv] then
+                output.puts render_csv(table)
+              else
+                output.puts table.render(if @options[:plain] then :basic else :ascii end, alignments: alignments, width: @options[:width] || TTY::Screen.width)
+              end
+            end if table
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/notifications.rb
+++ b/lib/gzr/commands/alert/notifications.rb
@@ -1,0 +1,74 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+require 'tty-table'
+
+module Gzr
+  module Commands
+    class Alert
+      class Notifications < Gzr::Command
+        include Gzr::Alert
+        def initialize(options)
+          super()
+          @options = options
+          @fields = "notification_id,alert_condition_id,user_id,is_read,field_value,threshold_value,ran_at,alert(title,alert_id,investigative_content_id,dashboard_name,dashboard_id,query_slug)"
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+            data = alert_notifications()
+
+            begin
+              puts "No notifications returned"
+              return nil
+            end unless data && data.length > 0
+
+            table_hash = Hash.new
+            fields = field_names(@fields)
+            table_hash[:header] = fields unless @options[:plain]
+            expressions = fields.collect { |fn| field_expression(fn) }
+            table_hash[:rows] = data.map do |row|
+              expressions.collect do |e|
+                eval "row.#{e}"
+              end
+            end
+            table = TTY::Table.new(table_hash)
+            alignments = fields.collect do |k|
+              (k =~ /id$/) ? :right : :left
+            end
+            begin
+              if @options[:csv] then
+                output.puts render_csv(table)
+              else
+                output.puts table.render(if @options[:plain] then :basic else :ascii end, alignments: alignments, width: @options[:width] || TTY::Screen.width)
+              end
+            end if table
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/notifications.rb
+++ b/lib/gzr/commands/alert/notifications.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/read.rb
+++ b/lib/gzr/commands/alert/read.rb
@@ -1,0 +1,49 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+
+module Gzr
+  module Commands
+    class Alert
+      class Read < Gzr::Command
+        include Gzr::Alert
+        def initialize(notification_id,options)
+          super()
+          @notification_id = notification_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+           data = read_alert_notification(@notification_id)
+           output.puts JSON.pretty_generate(data) unless (data.nil? || data.empty?)
+           output.puts "No notification found" if (data.nil? || data.empty?)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/read.rb
+++ b/lib/gzr/commands/alert/read.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/threshold.rb
+++ b/lib/gzr/commands/alert/threshold.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/threshold.rb
+++ b/lib/gzr/commands/alert/threshold.rb
@@ -1,0 +1,48 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+
+module Gzr
+  module Commands
+    class Alert
+      class Threshold < Gzr::Command
+        include Gzr::Alert
+        def initialize(alert_id, threshold, options)
+          super()
+          @alert_id = alert_id
+          @threshold = threshold
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+           update_alert_field(@alert_id, threshold: @threshold)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/alert/unfollow.rb
+++ b/lib/gzr/commands/alert/unfollow.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/alert/unfollow.rb
+++ b/lib/gzr/commands/alert/unfollow.rb
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+
+module Gzr
+  module Commands
+    class Alert
+      class Unfollow < Gzr::Command
+        include Gzr::Alert
+        def initialize(alert_id,options)
+          super()
+          @alert_id = alert_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+           unfollow_alert(@alert_id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/dashboard/cat.rb
+++ b/lib/gzr/commands/dashboard/cat.rb
@@ -25,7 +25,6 @@ require 'json'
 require_relative '../../command'
 require_relative '../../modules/dashboard'
 require_relative '../../modules/plan'
-require_relative '../../modules/alert'
 require_relative '../../modules/filehelper'
 
 module Gzr
@@ -34,7 +33,6 @@ module Gzr
       class Cat < Gzr::Command
         include Gzr::Dashboard
         include Gzr::FileHelper
-        include Gzr::Alert
         include Gzr::Plan
         def initialize(dashboard_id,options)
           super()
@@ -47,13 +45,6 @@ module Gzr
           with_session do
             data = cat_dashboard(@dashboard_id)
             data = trim_dashboard(data) if @options[:trim]
-
-            alerts = search_alerts(fields: 'id,dashboard_element_id', group_by: 'dashboard', all_owners: true)
-            alerts.map!{|v| v.to_attrs}
-            say_warning alerts if @options[:debug]
-            data[:dashboard_elements].each do |e|
-              e[:alerts] = alerts.select { |a| a[:dashboard_element_id] == e[:id]}.map { |a| get_alert(a[:id]).to_attrs }
-            end
 
             replacements = {}
             if @options[:transform]

--- a/lib/gzr/commands/dashboard/cat.rb
+++ b/lib/gzr/commands/dashboard/cat.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/dashboard/cat.rb
+++ b/lib/gzr/commands/dashboard/cat.rb
@@ -25,6 +25,7 @@ require 'json'
 require_relative '../../command'
 require_relative '../../modules/dashboard'
 require_relative '../../modules/plan'
+require_relative '../../modules/alert'
 require_relative '../../modules/filehelper'
 
 module Gzr
@@ -33,6 +34,7 @@ module Gzr
       class Cat < Gzr::Command
         include Gzr::Dashboard
         include Gzr::FileHelper
+        include Gzr::Alert
         include Gzr::Plan
         def initialize(dashboard_id,options)
           super()
@@ -45,6 +47,13 @@ module Gzr
           with_session do
             data = cat_dashboard(@dashboard_id)
             data = trim_dashboard(data) if @options[:trim]
+
+            alerts = search_alerts(fields: 'id,dashboard_element_id', group_by: 'dashboard', all_owners: true)
+            alerts.map!{|v| v.to_attrs}
+            say_warning alerts if @options[:debug]
+            data[:dashboard_elements].each do |e|
+              e[:alerts] = alerts.select { |a| a[:dashboard_element_id] == e[:id]}.map { |a| get_alert(a[:id]).to_attrs }
+            end
 
             replacements = {}
             if @options[:transform]

--- a/lib/gzr/commands/dashboard/import.rb
+++ b/lib/gzr/commands/dashboard/import.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/commands/dashboard/import.rb
+++ b/lib/gzr/commands/dashboard/import.rb
@@ -89,6 +89,17 @@ module Gzr
                 element[:result_maker] = result_maker if result_maker
                 dashboard_element = create_dashboard_element(element)
                 say_warning "dashboard_element #{dashboard_element.inspect}" if @options[:debug]
+                if new_element[:alerts]
+                  new_element[:alerts].each do |a|
+                    a.select! do |k,v|
+                      (keys_to_keep('create_alert') - [:owner_id, :dashboard_element_id]).include? k
+                    end
+                    a[:dashboard_element_id] = dashboard_element[:id]
+                    a[:owner_id] = @me[:id]
+                    new_alert = create_alert(a)
+                    say_warning "alert #{JSON.pretty_generate(new_alert)}" if @options[:debug]
+                  end
+                end
                 dashboard[:dashboard_elements].push dashboard_element
                 [new_element[:id], dashboard_element.id]
               end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -91,5 +91,23 @@ module Gzr
         raise
       end
     end
+
+    def update_alert_field(alert_id, owner_id: nil, is_disabled: nil, disabled_reason: nil, is_public: nil, threshold: nil)
+      req = {}
+      req[:owner_id] = owner_id unless owner_id.nil?
+      req[:is_disabled] = is_disabled unless is_disabled.nil?
+      req[:disabled_reason] = disabled_reason unless disabled_reason.nil?
+      req[:is_public] = is_public unless is_public.nil?
+      req[:threshold] = threshold unless threshold.nil?
+      data = nil
+      begin
+        data = @sdk.update_alert_field(alert_id, req)
+      rescue LookerSDK::Error => e
+        say_error "Error calling update_alert_field(#{alert_id},#{JSON.pretty_generate(req)})"
+        say_error e
+        raise
+      end
+      data
+    end
   end
 end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -109,5 +109,15 @@ module Gzr
       end
       data
     end
+
+    def delete_alert(alert_id)
+      begin
+        @sdk.delete_alert(alert_id)
+      rescue LookerSDK::Error => e
+        say_error "Error calling delete_alert(#{alert_id})"
+        say_error e
+        raise
+      end
+    end
   end
 end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -30,9 +30,15 @@ module Gzr
       rescue LookerSDK::NotFound => e
         # do nothing
       rescue LookerSDK::Error => e
-        say_error "Error querying user_attribute(#{attr_id},#{JSON.pretty_generate(req)})"
+        say_error "Error querying get_alert(#{alert_id})"
         say_error e
         raise
+      end
+      if data[:owner_id]
+        owner = get_user_by_id(data[:owner_id])
+        data[:owner] = owner.to_attrs.select do |k,v|
+          [:email,:last_name,:first_name].include?(k) || ( k.to_s.start_with?('credentials')  && !(v.nil? || v.empty?))
+        end
       end
       data
     end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -1,0 +1,56 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+module Gzr
+  module Alert
+    def get_alert(alert_id)
+      data = nil
+      begin
+        data = @sdk.get_alert(alert_id)
+      rescue LookerSDK::NotFound => e
+        # do nothing
+      rescue LookerSDK::Error => e
+        say_error "Error querying user_attribute(#{attr_id},#{JSON.pretty_generate(req)})"
+        say_error e
+        raise
+      end
+      data
+    end
+
+    def search_alerts(fields=nil)
+      data = nil
+      begin
+        req = {}
+        req[:fields] = fields if fields
+        data = @sdk.search_alerts(req)
+      rescue LookerSDK::NotFound => e
+        # do nothing
+      rescue LookerSDK::Error => e
+        say_error "Error querying alerts(#{JSON.pretty_generate(req)})"
+        say_error e
+        raise
+      end
+      data
+    end
+  end
+end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -55,7 +55,6 @@ module Gzr
         req[:last_run_start] = last_run_start unless last_run_start.nil?
         req[:last_run_end] = last_run_end unless last_run_end.nil?
         req[:all_owners] = all_owners unless all_owners.nil?
-        say_warning(req)
         req[:limit] = 64
         loop do
           page = @sdk.search_alerts(req)

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -37,16 +37,30 @@ module Gzr
       data
     end
 
-    def search_alerts(fields=nil)
-      data = nil
+    def search_alerts(group_by: nil, fields: nil, disabled: nil, frequency: nil, condition_met: nil, last_run_start: nil, last_run_end: nil, all_owners: nil)
+      data = []
       begin
         req = {}
-        req[:fields] = fields if fields
-        data = @sdk.search_alerts(req)
+        req[:group_by] = group_by unless group_by.nil?
+        req[:fields] = fields unless fields.nil?
+        req[:disabled] = disabled unless disabled.nil?
+        req[:frequency] = frequency unless frequency.nil?
+        req[:condition_met] = condition_met unless condition_met.nil?
+        req[:last_run_start] = last_run_start unless last_run_start.nil?
+        req[:last_run_end] = last_run_end unless last_run_end.nil?
+        req[:all_owners] = all_owners unless all_owners.nil?
+        say_warning(req)
+        req[:limit] = 64
+        loop do
+          page = @sdk.search_alerts(req)
+          data+=page
+          break unless page.length == req[:limit]
+          req[:offset] = (req[:offset] || 0) + req[:limit]
+        end
       rescue LookerSDK::NotFound => e
         # do nothing
       rescue LookerSDK::Error => e
-        say_error "Error querying alerts(#{JSON.pretty_generate(req)})"
+        say_error "Error querying search_alerts(#{JSON.pretty_generate(req)})"
         say_error e
         raise
       end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -153,5 +153,17 @@ module Gzr
       data.to_attrs
     end
 
+    def create_alert(req)
+      data = nil
+      begin
+        data = @sdk.create_alert(req)
+      rescue LookerSDK::Error => e
+        say_error "Error calling create_alert(#{JSON.pretty_generate(req)})"
+        say_error e
+        raise
+      end
+      data.to_attrs
+    end
+
   end
 end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -119,5 +119,39 @@ module Gzr
         raise
       end
     end
+
+    def alert_notifications()
+      data = []
+      req = {}
+      begin
+        req[:limit] = 64
+        loop do
+          page = @sdk.alert_notifications(req)
+          data+=page
+          break unless page.length == req[:limit]
+          req[:offset] = (req[:offset] || 0) + req[:limit]
+        end
+      rescue LookerSDK::NotFound => e
+        # do nothing
+      rescue LookerSDK::Error => e
+        say_error "Error querying alert_notifications()"
+        say_error e
+        raise
+      end
+      data
+    end
+
+    def read_alert_notification(notification_id)
+      data = nil
+      begin
+        data = @sdk.read_alert_notification(notification_id)
+      rescue LookerSDK::Error => e
+        say_error "Error calling read_alert_notification(#{notification_id})"
+        say_error e
+        raise
+      end
+      data.to_attrs
+    end
+
   end
 end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Looker Data Sciences, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -37,7 +37,7 @@ module Gzr
       if data[:owner_id]
         owner = get_user_by_id(data[:owner_id])
         data[:owner] = owner.to_attrs.select do |k,v|
-          [:email,:last_name,:first_name].include?(k) || ( k.to_s.start_with?('credentials')  && !(v.nil? || v.empty?))
+          [:email,:last_name,:first_name].include?(k) && !(v.nil? || v.empty?)
         end
       end
       data

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -72,5 +72,25 @@ module Gzr
       end
       data
     end
+
+    def follow_alert(alert_id)
+      begin
+        @sdk.follow_alert(alert_id)
+      rescue LookerSDK::Error => e
+        say_error "Error following alert(#{alert_id})"
+        say_error e
+        raise
+      end
+    end
+
+    def unfollow_alert(alert_id)
+      begin
+        @sdk.unfollow_alert(alert_id)
+      rescue LookerSDK::Error => e
+        say_error "Error following alert(#{alert_id})"
+        say_error e
+        raise
+      end
+    end
   end
 end

--- a/lib/gzr/modules/dashboard.rb
+++ b/lib/gzr/modules/dashboard.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
```
$ gzr alert help
Commands:
  gzr alert cat ALERT_ID                        # Output json information about an alert to screen or file
  gzr alert chown ALERT_ID OWNER_ID             # Change the owner of the alert given by ALERT_ID to OWNER_ID
  gzr alert disable ALERT_ID REASON             # Disable the alert given by ALERT_ID
  gzr alert enable ALERT_ID                     # Enable the alert given by ALERT_ID
  gzr alert follow ALERT_ID                     # Start following the alert given by ALERT_ID
  gzr alert help [COMMAND]                      # Describe subcommands or one specific subcommand
  gzr alert import FILE [DASHBOARD_ELEMENT_ID]  # Import an alert from a file
  gzr alert ls                                  # list alerts
  gzr alert notifications                       # Get notifications
  gzr alert read NOTIFICATION_ID                # Read notification id
  gzr alert rm ALERT_ID                         # Delete the alert given by ALERT_ID
  gzr alert threshold ALERT_ID THRESHOLD        # Change the threshold of the alert given by ALERT_ID
  gzr alert unfollow ALERT_ID                   # Stop following the alert given by ALERT_ID
```