### PR TITLE
feat: Persistent tokens for login

### DIFF
--- a/lib/gzr/cli.rb
+++ b/lib/gzr/cli.rb
@@ -46,6 +46,8 @@ module Gzr
     class_option :su, type: :string, desc: 'After connecting, change to user_id given'
     class_option :width, type: :numeric, default: nil, desc: 'Width of rendering for tables'
     class_option :persistent, type: :boolean, default: false, desc: 'Use persistent connection to communicate with host'
+    class_option :token, type: :string, default: nil, desc: "Access token to use for authentication"
+    class_option :token_file, type: :boolean, default: false, desc: "Use access token stored in file for authentication"
 
     # Error raised by this runner
     Error = Class.new(StandardError)
@@ -96,5 +98,8 @@ module Gzr
 
     require_relative 'commands/folder'
     register Gzr::Commands::Folder, 'folder', 'folder [SUBCOMMAND]', 'Commands pertaining to folders'
+
+    require_relative 'commands/session'
+    register Gzr::Commands::Session, 'session', 'session [SUBCOMMAND]', 'Commands pertaining to sessions'
   end
 end

--- a/lib/gzr/commands/session.rb
+++ b/lib/gzr/commands/session.rb
@@ -1,0 +1,56 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require 'thor'
+
+module Gzr
+  module Commands
+    class Session < Thor
+
+      namespace :session
+
+      desc 'login', 'Create a persistent session'
+      method_option :text, type: :boolean, default: false,
+                           desc: 'output token to screen instead of file'
+      def login(*)
+        if options[:help]
+          invoke :help, ['login']
+        else
+          require_relative 'session/login'
+          Gzr::Commands::Session::Login.new(options).execute
+        end
+      end
+
+      desc 'logout', 'End a persistent session'
+      def logout(*)
+        if options[:help]
+          invoke :help, ['logout']
+        else
+          require_relative 'session/logout'
+          Gzr::Commands::Session::Logout.new(options).execute
+        end
+      end
+
+    end
+  end
+end

--- a/lib/gzr/commands/session/login.rb
+++ b/lib/gzr/commands/session/login.rb
@@ -1,0 +1,50 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+
+module Gzr
+  module Commands
+    class Session
+      class Login < Gzr::Command
+        def initialize(options)
+          super()
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          login
+          if @options[:text]
+            puts @sdk.access_token
+            return
+          end
+          token_data = read_token_data || {}
+          token_data[@options[:host].to_sym] ||= {}
+          token_data[@options[:host].to_sym][@options[:su]&.to_sym || :default] = @sdk.access_token
+          write_token_data(token_data)
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/session/login.rb
+++ b/lib/gzr/commands/session/login.rb
@@ -41,7 +41,7 @@ module Gzr
           end
           token_data = read_token_data || {}
           token_data[@options[:host].to_sym] ||= {}
-          token_data[@options[:host].to_sym][@options[:su]&.to_sym || :default] = @sdk.access_token
+          token_data[@options[:host].to_sym][@options[:su]&.to_sym || :default] = { token: @sdk.access_token, expiration: @sdk.access_token_expires_at }
           write_token_data(token_data)
         end
       end

--- a/lib/gzr/commands/session/logout.rb
+++ b/lib/gzr/commands/session/logout.rb
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+
+module Gzr
+  module Commands
+    class Session
+      class Logout < Gzr::Command
+        def initialize(options)
+          super()
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          login
+          @sdk.logout
+          token_data = read_token_data || {}
+          token_data[@options[:host].to_sym] ||= {}
+          token_data[@options[:host].to_sym]&.delete(@options[:su]&.to_sym || :default)
+          write_token_data(token_data)
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/modules/session.rb
+++ b/lib/gzr/modules/session.rb
@@ -227,8 +227,8 @@ module Gzr
           time_parts = time.split(':')
           date_time_parts = day_parts + time_parts + [tz]
           expiration = Time.new(*date_time_parts)
-          if expiration < Time.now
-            say_error "token expired at #{expiration}"
+          if expiration < (Time.now + 300)
+            say_error "token expires at #{expiration}, which is in the past or the next 5 minutes"
             say_error "login again with gzr session login"
             raise LookerSDK::Unauthorized.new
           end

--- a/lib/gzr/modules/session.rb
+++ b/lib/gzr/modules/session.rb
@@ -55,6 +55,38 @@ module Gzr
       !versions.drop_while {|v| v < minimum_version}.reverse.drop_while {|v| v > given_version}.empty?
     end
 
+    def token_file
+      "#{ENV["HOME"]}/.gzr_auth"
+    end
+
+    def read_token_data
+      return nil unless File.exist?(token_file)
+      s = File.stat(token_file)
+      if !(s.mode.to_s(8)[3..5] == "600")
+        say_error "#{token_file} mode is #{s.mode.to_s(8)[3..5]}. It must be 600. Ignoring."
+        return nil
+      end
+      token_data = nil
+      file = nil
+      begin
+        file = File.open(token_file)
+        token_data = JSON.parse(file.read,{:symbolize_names => true})
+      ensure
+        file.close if file
+      end
+      token_data
+    end
+
+    def write_token_data(token_data)
+      file = nil
+      begin
+        file = File.new(token_file, "wt")
+        file.chmod(0600)
+        file.write JSON.pretty_generate(token_data)
+      ensure
+        file.close if file
+      end
+    end
 
     def build_connection_hash(api_version=nil)
       conn_hash = Hash.new
@@ -86,6 +118,9 @@ module Gzr
         }
       end
       conn_hash[:user_agent] = "Gazer #{Gzr::VERSION}"
+
+      return conn_hash if @options[:token] || @options[:token_file]
+
       if @options[:client_id] then
         conn_hash[:client_id] = @options[:client_id]
         if @options[:client_secret] then
@@ -103,12 +138,14 @@ module Gzr
     end
 
     def login(min_api_version="4.0")
-      if (@options[:client_id].nil? && ENV["LOOKERSDK_CLIENT_ID"])
-        @options[:client_id] = ENV["LOOKERSDK_CLIENT_ID"]
-      end
+      if !@options[:token] && !@options[:token_file]
+        if (@options[:client_id].nil? && ENV["LOOKERSDK_CLIENT_ID"])
+          @options[:client_id] = ENV["LOOKERSDK_CLIENT_ID"]
+        end
 
-      if (@options[:client_secret].nil? && ENV["LOOKERSDK_CLIENT_SECRET"])
-        @options[:client_secret] = ENV["LOOKERSDK_CLIENT_SECRET"]
+        if (@options[:client_secret].nil? && ENV["LOOKERSDK_CLIENT_SECRET"])
+          @options[:client_secret] = ENV["LOOKERSDK_CLIENT_SECRET"]
+        end
       end
 
       if (@options[:verify_ssl] && ENV["LOOKERSDK_VERIFY_SSL"])
@@ -183,6 +220,11 @@ module Gzr
         @sdk = LookerSDK::Client.new(conn_hash.merge(faraday: faraday)) unless @sdk
 
         say_ok "check for connectivity: #{@sdk.alive?}" if @options[:debug]
+        if @options[:token_file]
+          @sdk.access_token = read_token_data&.fetch(@options[:host].to_sym,nil)&.fetch(:default,nil)
+        elsif @options[:token]
+          @sdk.access_token = @options[:token]
+        end
         say_ok "verify authentication: #{@sdk.authenticated?}" if @options[:debug]
       rescue LookerSDK::Unauthorized => e
         say_error "Unauthorized - credentials are not valid"
@@ -247,7 +289,7 @@ module Gzr
         e.backtrace.each { |b| say_error b } if @options[:debug]
         raise Gzr::CLI::Error, e.message
       ensure
-        logout_all
+        logout_all unless @options[:token] || @options[:token_file]
       end
     end
   end


### PR DESCRIPTION
```
$ gzr session help
Commands:
  gzr session help [COMMAND]  # Describe subcommands or one specific subcommand
  gzr session login           # Create a persistent session
  gzr session logout          # End a persistent session
```

Now you can use a command like `gzr session login --host ... ` and Gazer will login and store the access token. Then you can run other commands like `gzr COMMAND SUBCOMMAND --token_file --host ...` and Gazer will use the existing token rather than logging in and out every time. The command `gzr session logout --token_file --host ...` can be used to manually log out the token. The token also expires after 1 hour.

Alternately, you can do the following, especially if you don't have write access for the token file.
```
TOKEN=$(gzr session login --text --host ...)
# This will store the token in the environment variable TOKEN
# The --text switch outputs the token to the screen instead of writing it to a file.
gzr COMMAND SUBCOMMAND --token $TOKEN --host ...
# The --token switch gets the token from the command line
gzr COMMAND SUBCOMMAND --token $TOKEN --host ...
gzr COMMAND SUBCOMMAND --token $TOKEN --host ...
gzr session logout --token $TOKEN --host ...
```

The persistent session token is of minor utility right now, but it will enable features in the future that require working with a session in developer mode.
