### PR TITLE
feat: Connection handling with Gazer

### DIFF
--- a/lib/gzr/commands/connection.rb
+++ b/lib/gzr/commands/connection.rb
@@ -65,7 +65,7 @@ module Gzr
         end
       end
 
-      desc 'cat CONNECTION_ID', 'Output the JSON representation of a connection to the screen or a file'
+      desc 'cat CONNECTION_NAME', 'Output the JSON representation of a connection to the screen or a file'
       method_option :help, aliases: '-h', type: :boolean,
                            desc: 'Display usage information'
       method_option :dir,  type: :string,
@@ -74,12 +74,60 @@ module Gzr
                            desc: 'Use simple filename for output (Connection_<id>.json)'
       method_option :trim, type: :boolean,
                            desc: 'Trim output to minimal set of fields for later import'
-      def cat(connection_id)
+      def cat(connection_name)
         if options[:help]
           invoke :help, ['cat']
         else
           require_relative 'connection/cat'
-          Gzr::Commands::Connection::Cat.new(connection_id, options).execute
+          Gzr::Commands::Connection::Cat.new(connection_name, options).execute
+        end
+      end
+
+      desc 'rm CONNECTION_NAME', 'Delete a connection'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      def rm(connection_name)
+        if options[:help]
+          invoke :help, ['rm']
+        else
+          require_relative 'connection/rm'
+          Gzr::Commands::Connection::Rm.new(connection_name, options).execute
+        end
+      end
+
+      desc 'import FILE', 'Import a connection from a file'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :force, type: :boolean,
+                           desc: 'Overwrite an existing connection'
+      method_option :prompt, type: :boolean,
+                           desc: 'Prompt for the password'
+      method_option :plain, type: :boolean, default: false,
+                           desc: 'print without any extra formatting'
+      def import(file)
+        if options[:help]
+          invoke :help, ['import']
+        else
+          require_relative 'connection/import'
+          Gzr::Commands::Connection::Import.new(file, options).execute
+        end
+      end
+
+      desc 'test CONNECTION_NAME', 'Test the given connection'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :fields, type: :string, default: 'name,status,message',
+                           desc: 'Fields to display'
+      method_option :plain, type: :boolean, default: false,
+                           desc: 'print without any extra formatting'
+      method_option :csv, type: :boolean, default: false,
+                           desc: 'output in csv format per RFC4180'
+      def test(connection_name)
+        if options[:help]
+          invoke :help, ['test']
+        else
+          require_relative 'connection/test'
+          Gzr::Commands::Connection::Test.new(connection_name,options).execute
         end
       end
     end

--- a/lib/gzr/commands/connection.rb
+++ b/lib/gzr/commands/connection.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -62,6 +62,24 @@ module Gzr
         else
           require_relative 'connection/ls'
           Gzr::Commands::Connection::Ls.new(options).execute
+        end
+      end
+
+      desc 'cat CONNECTION_ID', 'Output the JSON representation of a connection to the screen or a file'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :dir,  type: :string,
+                           desc: 'Directory to store output file'
+      method_option :simple_filename, type: :boolean,
+                           desc: 'Use simple filename for output (Connection_<id>.json)'
+      method_option :trim, type: :boolean,
+                           desc: 'Trim output to minimal set of fields for later import'
+      def cat(connection_id)
+        if options[:help]
+          invoke :help, ['cat']
+        else
+          require_relative 'connection/cat'
+          Gzr::Commands::Connection::Cat.new(connection_id, options).execute
         end
       end
     end

--- a/lib/gzr/commands/connection/cat.rb
+++ b/lib/gzr/commands/connection/cat.rb
@@ -1,0 +1,63 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../../command'
+require_relative '../../modules/connection'
+require_relative '../../modules/filehelper'
+
+module Gzr
+  module Commands
+    class Connection
+      class Cat < Gzr::Command
+        include Gzr::Connection
+        include Gzr::FileHelper
+        def initialize(connection_id,options)
+          super()
+          @connection_id = connection_id
+          @options = options
+        end
+
+        def execute(*args, input: $stdin, output: $stdout)
+          say_warning("options: #{@options.inspect}") if @options[:debug]
+          with_session do
+            data = cat_connection(@connection_id)
+            data = trim_connection(data) if @options[:trim]
+            return unless data
+
+            outputJSON = JSON.pretty_generate(data)
+
+            file_name = if @options[:dir]
+                          @options[:simple_filename] ? "Connection_#{data[:name]}.json" : "Connection_#{data[:name]}_#{data[:dialect_name]}.json"
+                        else
+                          nil
+                        end
+            write_file(file_name, @options[:dir], nil, output) do |f|
+              f.puts outputJSON
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/connection/import.rb
+++ b/lib/gzr/commands/connection/import.rb
@@ -46,6 +46,7 @@ module Gzr
             if @options[:prompt]
               reader = TTY::Reader.new
               @secret = reader.read_line("Enter your connection password:", echo: false)
+              @secret.chomp!
             end
 
             read_file(@file) do |data|

--- a/lib/gzr/commands/connection/rm.rb
+++ b/lib/gzr/commands/connection/rm.rb
@@ -29,35 +29,19 @@ require_relative '../../modules/filehelper'
 module Gzr
   module Commands
     class Connection
-      class Cat < Gzr::Command
+      class Rm < Gzr::Command
         include Gzr::Connection
         include Gzr::FileHelper
-        def initialize(connection_id,options)
+        def initialize(connection_name,options)
           super()
-          @connection_id = connection_id
+          @connection_name = connection_name
           @options = options
         end
 
         def execute(*args, input: $stdin, output: $stdout)
           say_warning("options: #{@options.inspect}") if @options[:debug]
           with_session do
-            data = cat_connection(@connection_id)
-            if data.nil?
-              say_warning "Connection #{@connection_id} not found"
-              return
-            end
-            data = trim_connection(data) if @options[:trim]
-
-            outputJSON = JSON.pretty_generate(data)
-
-            file_name = if @options[:dir]
-                          @options[:simple_filename] ? "Connection_#{data[:name]}.json" : "Connection_#{data[:name]}_#{data[:dialect_name]}.json"
-                        else
-                          nil
-                        end
-            write_file(file_name, @options[:dir], nil, output) do |f|
-              f.puts outputJSON
-            end
+            delete_connection(@connection_name)
           end
         end
       end

--- a/lib/gzr/modules/connection.rb
+++ b/lib/gzr/modules/connection.rb
@@ -48,5 +48,24 @@ module Gzr
       data
     end
 
+    def cat_connection(name)
+      data = nil
+      begin
+        data = @sdk.connection(name).to_attrs
+      rescue LookerSDK::NotFound => e
+        say_warning "Connection #{name} not found"
+      rescue LookerSDK::Error => e
+        say_error "Error executing connection(#{name})"
+        say_error e
+        raise
+      end
+      data
+    end
+
+    def trim_connection(data)
+      data.select do |k,v|
+        (keys_to_keep('create_connection') + [:pdt_context_override]).include? k
+      end
+    end
   end
 end

--- a/lib/gzr/modules/connection.rb
+++ b/lib/gzr/modules/connection.rb
@@ -48,12 +48,73 @@ module Gzr
       data
     end
 
+    def test_connection(name, tests=nil)
+      data = nil
+
+      if tests.nil?
+        connection = cat_connection(name)
+        if connection.nil?
+          return nil
+        end
+        tests = connection[:dialect][:connection_tests]
+      end
+
+      begin
+        data = @sdk.test_connection(name, {}, tests: tests)
+      rescue LookerSDK::NotFound => e
+        return nil
+      rescue LookerSDK::Error => e
+        say_error "Error executing test_connection(#{name},#{tests})"
+        say_error e
+        raise
+      end
+      data
+    end
+
+    def delete_connection(name)
+      begin
+        @sdk.delete_connection(name)
+      rescue LookerSDK::NotFound => e
+        say_warning "Connection #{name} not found"
+      rescue LookerSDK::Error => e
+        say_error "Error executing delete_connection(#{name})"
+        say_error e
+        raise
+      end
+    end
+
+    def create_connection(body)
+      data = nil
+      begin
+        data = @sdk.create_connection(body).to_attrs
+      rescue LookerSDK::Error => e
+        say_error "Error executing create_connection(#{JSON.pretty_generate(body)})"
+        say_error e
+        raise
+      end
+      data
+    end
+
+    def update_connection(name,body)
+      data = nil
+      begin
+        data = @sdk.connection(name,body).to_attrs
+      rescue LookerSDK::NotFound => e
+        say_warning "Connection #{name} not found"
+      rescue LookerSDK::Error => e
+        say_error "Error executing update_connection(#{name},#{JSON.pretty_generate(body)})"
+        say_error e
+        raise
+      end
+      data
+    end
+
     def cat_connection(name)
       data = nil
       begin
         data = @sdk.connection(name).to_attrs
       rescue LookerSDK::NotFound => e
-        say_warning "Connection #{name} not found"
+        return nil
       rescue LookerSDK::Error => e
         say_error "Error executing connection(#{name})"
         say_error e


### PR DESCRIPTION
Added `cat`, `rm`, `test`, and `import` commands.

```
$ exe/gzr help connection
Commands:
  gzr connection cat CONNECTION_NAME   # Output the JSON representation of a connection to the screen or a file
  gzr connection dialects              # List all available dialects
  gzr connection help [COMMAND]        # Describe subcommands or one specific subcommand
  gzr connection import FILE           # Import a connection from a file
  gzr connection ls                    # List all available connections
  gzr connection rm CONNECTION_NAME    # Delete a connection
  gzr connection test CONNECTION_NAME  # Test the given connection
```