### PR TITLE
feat: Project management and session management additions

### DIFF
--- a/lib/gzr/cli.rb
+++ b/lib/gzr/cli.rb
@@ -101,5 +101,8 @@ module Gzr
 
     require_relative 'commands/session'
     register Gzr::Commands::Session, 'session', 'session [SUBCOMMAND]', 'Commands pertaining to sessions'
+
+    require_relative 'commands/project'
+    register Gzr::Commands::Project, 'project', 'project [SUBCOMMAND]', 'Commands pertaining to projects'
   end
 end

--- a/lib/gzr/commands/project.rb
+++ b/lib/gzr/commands/project.rb
@@ -48,6 +48,22 @@ module Gzr
         end
       end
 
+      desc 'cat PROJECT_ID', 'Output json information about a project to screen or file'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :dir,  type: :string,
+                           desc: 'Directory to store output file'
+      method_option :trim, type: :boolean,
+                           desc: 'Trim output to minimal set of fields for later import'
+      def cat(project_id)
+        if options[:help]
+          invoke :help, ['cat']
+        else
+          require_relative 'project/cat'
+          Gzr::Commands::Project::Cat.new(project_id,options).execute
+        end
+      end
+
     end
   end
 end

--- a/lib/gzr/commands/project.rb
+++ b/lib/gzr/commands/project.rb
@@ -1,0 +1,53 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require 'thor'
+
+module Gzr
+  module Commands
+    class Project < Thor
+
+      namespace :project
+
+      desc 'ls', 'List all projects'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :fields, type: :string, default: 'id,name,git_production_branch_name',
+                           desc: 'Fields to display'
+      method_option :plain, type: :boolean, default: false,
+                           desc: 'print without any extra formatting'
+      method_option :csv, type: :boolean, default: false,
+                           desc: 'output in csv format per RFC4180'
+
+      def ls(*)
+        if options[:help]
+          invoke :help, ['ls']
+        else
+          require_relative 'project/ls'
+          Gzr::Commands::Project::Ls.new(options).execute
+        end
+      end
+
+    end
+  end
+end

--- a/lib/gzr/commands/project/cat.rb
+++ b/lib/gzr/commands/project/cat.rb
@@ -1,0 +1,58 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/project'
+require_relative '../../modules/filehelper'
+
+module Gzr
+  module Commands
+    class Project
+      class Cat < Gzr::Command
+        include Gzr::Project
+        include Gzr::FileHelper
+        def initialize(project_id,options)
+          super()
+          @project_id = project_id
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+            data = cat_project(@project_id)
+            if data.nil?
+              say_warning "Project #{@project_id} not found"
+              return
+            end
+            data = trim_project(data) if @options[:trim]
+
+            write_file(@options[:dir] ? "Project_#{project.id}.json" : nil, @options[:dir],nil, output) do |f|
+              f.puts JSON.pretty_generate(data)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/project/ls.rb
+++ b/lib/gzr/commands/project/ls.rb
@@ -1,0 +1,73 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2018 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/project'
+require 'tty-table'
+
+module Gzr
+  module Commands
+    class Project
+      class Ls < Gzr::Command
+        include Gzr::Project
+        def initialize(options)
+          super()
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+            say_warning "querying all_projects({ fields: '#{@options[:fields]}' })" if @options[:debug]
+            data = all_projects(fields: @options[:fields])
+            begin
+              say_ok "No projects found"
+              return nil
+            end unless data && data.length > 0
+
+            table_hash = Hash.new
+            fields = field_names(@options[:fields])
+            table_hash[:header] = fields unless @options[:plain]
+            expressions = fields.collect { |fn| field_expression(fn) }
+            table_hash[:rows] = data.map do |row|
+              expressions.collect do |e|
+                eval "row.#{e}"
+              end
+            end
+            table = TTY::Table.new(table_hash)
+            alignments = fields.collect do |k|
+              (k =~ /id$/) ? :right : :left
+            end
+            begin
+              if @options[:csv] then
+                output.puts render_csv(table)
+              else
+                output.puts table.render(if @options[:plain] then :basic else :ascii end, alignments: alignments, width: @options[:width] || TTY::Screen.width)
+              end
+            end if table
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/session.rb
+++ b/lib/gzr/commands/session.rb
@@ -51,6 +51,26 @@ module Gzr
         end
       end
 
+      desc 'get', 'Get data about current session'
+      def get(*)
+        if options[:help]
+          invoke :help, ['get']
+        else
+          require_relative 'session/get'
+          Gzr::Commands::Session::Get.new(options).execute
+        end
+      end
+
+      desc 'update WORKSPACE_ID', 'change the workspace_id of the current session'
+      def update(workspace_id)
+        if options[:help]
+          invoke :help, ['update']
+        else
+          require_relative 'session/update'
+          Gzr::Commands::Session::Update.new(workspace_id,options).execute
+        end
+      end
+
     end
   end
 end

--- a/lib/gzr/commands/session/get.rb
+++ b/lib/gzr/commands/session/get.rb
@@ -1,0 +1,47 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/session'
+
+module Gzr
+  module Commands
+    class Session
+      class Get < Gzr::Command
+        include Gzr::Session
+        def initialize(options)
+          super()
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          with_session do
+            auth = get_auth()
+            output.puts JSON.pretty_generate(auth)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/session/update.rb
+++ b/lib/gzr/commands/session/update.rb
@@ -1,0 +1,51 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/session'
+
+module Gzr
+  module Commands
+    class Session
+      class Update < Gzr::Command
+        include Gzr::Session
+        def initialize(workspace_id,options)
+          super()
+          @options = options
+          @workspace_id = workspace_id
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+          if !@options[:token] && !@options[:token_file]
+            say_warning "Setting the session workspace_id only makes sense with a persistent session using --token or --token_file options"
+          end
+          with_session do
+            auth = update_auth(@workspace_id)
+            output.puts JSON.pretty_generate(auth)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/modules/project.rb
+++ b/lib/gzr/modules/project.rb
@@ -1,0 +1,60 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2023 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+module Gzr
+  module Project
+
+    def all_projects(fields: 'id')
+      data = []
+      begin
+        data = @sdk.all_projects({ fields: fields })
+      rescue LookerSDK::NotFound => e
+        return []
+      rescue LookerSDK::Error => e
+        say_error "Error querying all_projects(#{fields})"
+        say_error e
+        raise
+      end
+      data
+    end
+
+    def cat_project(project_id)
+      begin
+        return @sdk.project(project_id)&.to_attrs
+      rescue LookerSDK::NotFound => e
+        return nil
+      rescue LookerSDK::Error => e
+        say_error "Error getting project(#{project_id})"
+        say_error e
+        raise
+      end
+    end
+
+    def trim_project(data)
+      data.select do |k,v|
+        keys_to_keep('create_project').include? k
+      end
+    end
+
+  end
+end

--- a/lib/gzr/modules/session.rb
+++ b/lib/gzr/modules/session.rb
@@ -312,5 +312,26 @@ module Gzr
         logout_all unless @options[:token] || @options[:token_file]
       end
     end
+
+    def get_auth()
+      begin
+        return @sdk.session()&.to_attrs
+      rescue LookerSDK::Error => e
+        say_error "Unable to run session()"
+        say_error e
+      end
+    end
+
+    def update_auth(workspace_id)
+      body = {}
+      body[:workspace_id] = workspace_id
+      begin
+        return @sdk.update_session(body)&.to_attrs
+      rescue LookerSDK::Error => e
+        say_error "Unable to run update_session(#{JSON.pretty_generate(body)})"
+        say_error e
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Initial project management commands `ls` and `cat`

```
$ exe/gzr project help
Commands:
  gzr project cat PROJECT_ID  # Output json information about a project to screen or file
  gzr project help [COMMAND]  # Describe subcommands or one specific subcommand
  gzr project ls              # List all projects
```

Workspace selection in session management
```
$ exe/gzr session help
Commands:
  gzr session get                  # Get data about current session
  gzr session help [COMMAND]       # Describe subcommands or one specific subcommand
  gzr session login                # Create a persistent session
  gzr session logout               # End a persistent session
  gzr session update WORKSPACE_ID  # change the workspace_id of the current session
```

The `gzr session get` command retrieves the workspace_id of the current session. The `gzr session update WORKSPACE_ID` sets the workspace to `production` or `dev`. `session update` only makes sense when using a persistent session.