### PR TITLE
feat: Alert randomization

### DIFF
--- a/lib/gzr/commands/alert.rb
+++ b/lib/gzr/commands/alert.rb
@@ -51,6 +51,22 @@ module Gzr
         end
       end
 
+      desc 'randomize', 'Randomize the scheduled alerts on a server'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :window, type: :numeric, default: 60,
+                           desc: 'Length of window'
+      method_option :all, type: :boolean,
+                           desc: 'Randomize all alerts regardless of owner'
+      def randomize(*)
+        if options[:help]
+          invoke :help, ['randomize']
+        else
+          require_relative 'alert/randomize'
+          Gzr::Commands::Alert::Randomize.new(options).execute
+        end
+      end
+
       desc 'cat ALERT_ID', 'Output json information about an alert to screen or file'
       method_option :help, aliases: '-h', type: :boolean,
                            desc: 'Display usage information'

--- a/lib/gzr/commands/alert/randomize.rb
+++ b/lib/gzr/commands/alert/randomize.rb
@@ -1,0 +1,82 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2024 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/alert'
+require_relative '../../modules/user'
+require_relative '../../modules/cron'
+
+module Gzr
+  module Commands
+    class Alert
+      class Randomize < Gzr::Command
+        include Gzr::Alert
+        include Gzr::User
+        include Gzr::Cron
+        def initialize(options)
+          super()
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning(@options) if @options[:debug]
+
+          window = @options[:window]
+          if window < 1 or window > 60
+            say_error("window must be between 1 and 60")
+            raise Gzr::CLI::Error.new()
+          end
+
+          with_session do
+            @me ||= query_me("id")
+
+            req = {}
+            req[:disabled] = false
+            req[:all_owners] = @options[:all] unless @options[:all].nil?
+            alerts = search_alerts(**req)
+            begin
+              say_ok "No alerts found"
+              return nil
+            end unless alerts && alerts.length > 0
+
+            alerts.each do |alert|
+              crontab = alert[:cron]
+              if crontab == ""
+                say_warning("skipping alert #{alert[:id]} with no cron")
+                next
+              end
+              crontab = randomize_cron(crontab, window)
+              begin
+                alert[:cron] = crontab
+                update_alert(alert[:id], alert)
+              rescue LookerSDK::UnprocessableEntity => e
+                say_warning("Skipping invalid entry")
+              end
+            end
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/commands/plan.rb
+++ b/lib/gzr/commands/plan.rb
@@ -144,6 +144,22 @@ module Gzr
           Gzr::Commands::Plan::Ls.new(options).execute
         end
       end
+
+      desc 'randomize', 'Randomize the scheduled plans on a server'
+      method_option :help, aliases: '-h', type: :boolean,
+                           desc: 'Display usage information'
+      method_option :window, type: :numeric, default: 60,
+                           desc: 'Length of window'
+      method_option :all, type: :boolean,
+                           desc: 'Randomize all plans regardless of owner'
+      def randomize(*)
+        if options[:help]
+          invoke :help, ['randomize']
+        else
+          require_relative 'plan/randomize'
+          Gzr::Commands::Plan::Randomize.new(options).execute
+        end
+      end
     end
   end
 end

--- a/lib/gzr/commands/plan/randomize.rb
+++ b/lib/gzr/commands/plan/randomize.rb
@@ -1,0 +1,72 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2024 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+require_relative '../../command'
+require_relative '../../modules/plan'
+require_relative '../../modules/user'
+require_relative '../../modules/cron'
+
+module Gzr
+  module Commands
+    class Plan
+      class Randomize < Gzr::Command
+        include Gzr::Plan
+        include Gzr::User
+        include Gzr::Cron
+        def initialize(options)
+          super()
+          @options = options
+        end
+
+        def execute(input: $stdin, output: $stdout)
+          say_warning("options: #{@options.inspect}") if @options[:debug]
+
+          window = @options[:window]
+          if window < 1 or window > 60
+            say_error("window must be between 1 and 60")
+            raise Gzr::CLI::Error.new()
+          end
+
+          with_session do
+            @me ||= query_me("id")
+
+            plans = query_all_scheduled_plans( @options[:all]?'all':@me[:id] )
+            plans.each do |plan|
+              crontab = plan[:crontab]
+              if crontab == ""
+                say_warning("skipping plan #{plan[:id]} with no crontab")
+                next
+              end
+              crontab = randomize_cron(crontab, window)
+              begin
+                update_scheduled_plan(plan[:id], { crontab: crontab })
+              rescue LookerSDK::UnprocessableEntity => e
+                say_warning("Skipping invalid entry")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gzr/modules/alert.rb
+++ b/lib/gzr/modules/alert.rb
@@ -178,5 +178,15 @@ module Gzr
         raise
       end
     end
+
+    def update_alert(alert_id,req)
+      begin
+        @sdk.update_alert(alert_id,req).to_attrs
+      rescue LookerSDK::Error => e
+        say_error "Error calling update_alert(#{alert_id}, #{JSON.pretty_generate(req)})"
+        say_error e
+        raise
+      end
+    end
   end
 end

--- a/lib/gzr/modules/cron.rb
+++ b/lib/gzr/modules/cron.rb
@@ -1,0 +1,51 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2024 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+module Gzr
+  module Cron
+    def randomize_cron(crontab, window=60)
+      cronfields = crontab.split(%r{\s+})
+      minute = cronfields[0].to_i
+      hour = cronfields[1].to_i
+      factor = rand(window) - (window/2)
+      minute = minute + factor
+      if minute < 0
+        hour = hour - 1
+        minute = minute + 60
+      end
+      if hour < 0
+        hour = 23
+      end
+      if minute > 59
+        hour = hour + 1
+        minute = minute - 60
+      end
+      if hour > 23
+        hour = 0
+      end
+      cronfields[0] = minute
+      cronfields[1] = hour
+      return cronfields.join(' ')
+    end
+  end
+end

--- a/spec/integration/alert/randomize_spec.rb
+++ b/spec/integration/alert/randomize_spec.rb
@@ -1,0 +1,41 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2024 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+RSpec.describe "`gzr alert randomize` command", type: :cli do
+  it "executes `gzr alert help randomize` command successfully" do
+    output = `gzr alert help randomize`
+    expected_output = <<-OUT
+Usage:
+  gzr alert randomize
+
+Options:
+  -h, [--help], [--no-help]  # Display usage information
+      [--window=N]           # Length of window
+                             # Default: 60
+      [--all], [--no-all]    # Randomize all alerts regardless of owner
+
+Randomize the scheduled alerts on a server
+    OUT
+
+    expect(output).to eq(expected_output)
+  end
+end
+

--- a/spec/integration/alert_spec.rb
+++ b/spec/integration/alert_spec.rb
@@ -1,0 +1,46 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2024 Mike DeAngelo Google, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+RSpec.describe "`gzr alert` command", type: :cli do
+  it "executes `gzr help alert` command successfully" do
+    output = `gzr help alert`
+    expected_output = <<-OUT
+Commands:
+  gzr alert cat ALERT_ID                        # Output json information about an alert to screen or file
+  gzr alert chown ALERT_ID OWNER_ID             # Change the owner of the alert given by ALERT_ID to OWNER_ID
+  gzr alert disable ALERT_ID REASON             # Disable the alert given by ALERT_ID
+  gzr alert enable ALERT_ID                     # Enable the alert given by ALERT_ID
+  gzr alert follow ALERT_ID                     # Start following the alert given by ALERT_ID
+  gzr alert help [COMMAND]                      # Describe subcommands or one specific subcommand
+  gzr alert import FILE [DASHBOARD_ELEMENT_ID]  # Import an alert from a file
+  gzr alert ls                                  # list alerts
+  gzr alert notifications                       # Get notifications
+  gzr alert randomize                           # Randomize the scheduled alerts on a server
+  gzr alert read NOTIFICATION_ID                # Read notification id
+  gzr alert rm ALERT_ID                         # Delete the alert given by ALERT_ID
+  gzr alert threshold ALERT_ID THRESHOLD        # Change the threshold of the alert given by ALERT_ID
+  gzr alert unfollow ALERT_ID                   # Stop following the alert given by ALERT_ID
+
+    OUT
+
+    expect(output).to eq(expected_output)
+  end
+end

--- a/spec/integration/plan/randomize_spec.rb
+++ b/spec/integration/plan/randomize_spec.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2018 Mike DeAngelo Looker Data Sciences, Inc.
+# Copyright (c) 2024 Mike DeAngelo Google, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -19,22 +19,20 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-RSpec.describe "`gzr plan` command", type: :cli do
-  it "executes `gzr help plan` command successfully" do
-    output = `gzr help plan`
+RSpec.describe "`gzr plan randomize` command", type: :cli do
+  it "executes `gzr plan help randomize` command successfully" do
+    output = `gzr plan help randomize`
     expected_output = <<-OUT
-Commands:
-  gzr plan cat PLAN_ID                       # Output the JSON representation of a scheduled plan to the screen or a file
-  gzr plan disable PLAN_ID                   # Disable the specified plan
-  gzr plan enable PLAN_ID                    # Enable the specified plan
-  gzr plan failures                          # Report all plans that failed in their most recent run attempt
-  gzr plan help [COMMAND]                    # Describe subcommands or one specific subcommand
-  gzr plan import PLAN_FILE OBJ_TYPE OBJ_ID  # Import a plan from a file
-  gzr plan ls                                # List the scheduled plans on a server
-  gzr plan randomize                         # Randomize the scheduled plans on a server
-  gzr plan rm PLAN_ID                        # Delete a scheduled plan
-  gzr plan runit PLAN_ID                     # Execute a saved plan immediately
+Usage:
+  gzr plan randomize
 
+Options:
+  -h, [--help], [--no-help]  # Display usage information
+      [--window=N]           # Length of window
+                             # Default: 60
+      [--all], [--no-all]    # Randomize all plans regardless of owner
+
+Randomize the scheduled plans on a server
     OUT
 
     expect(output).to eq(expected_output)


### PR DESCRIPTION
Change the time alerts run by a random number +/- 30 minutes with a default 60 minute window, or by a smaller window if specified with the `--window` flag. By default do this for owned alerts, or for all alerts if the `--all` flag is specified.