### PR TITLE
fix: update release-please config to use extra-files for Go

### DIFF
--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const Version = "0.4.0"
+const Version = "0.4.1" // x-release-please-version
 
 var VersionCmd = &cobra.Command{
 	Use:   "version",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,9 @@
     ".": {
       "release-type": "go",
       "package-name": "looker-cli",
-      "version-file": "internal/cmd/version.go",
+      "extra-files": [
+        "internal/cmd/version.go"
+      ],
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     }


### PR DESCRIPTION
This fixes the issue where internal/cmd/version.go was not being updated by release-please. We switch from 'version-file' to 'extra-files' and add the 'x-release-please-version' marker.
