### PR TITLE
fix: More fixes for dashboard import

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1729,3 +1729,68 @@ func TestDashboardImportCommand(t *testing.T) {
 		t.Errorf("expected 1 element created, got %d", doer.elementsCreated)
 	}
 }
+
+func TestDashboardImportFallbackCommand(t *testing.T) {
+	doer := &mockDoer{t: t}
+	MockSDK = v4.NewLookerSDK(doer)
+	defer func() { MockSDK = nil }()
+
+	dashJSON := `{
+  "title": "Test Fallback Dash",
+  "dashboard_elements": [
+    {
+      "title": "My Boxplot",
+      "type": "text",
+      "body_text": "hello"
+    }
+  ],
+  "dashboard_layouts": [
+    {
+      "id": "layout_1",
+      "active": true,
+      "dashboard_layout_components": [
+        {
+          "id": "comp_1",
+          "dashboard_element_id": "270",
+          "element_title": "My Boxplot"
+        }
+      ]
+    }
+  ]
+}`
+
+	tmpFile, err := os.CreateTemp("", "dashboard_import_fallback_*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write([]byte(dashJSON)); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	RootCmd.SetArgs([]string{"dashboard", "import", tmpFile.Name(), "801", "--plain"})
+	err = RootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	out := strings.TrimSpace(buf.String())
+
+	if out != "new_dash_1" {
+		t.Errorf("expected new_dash_1, got %s", out)
+	}
+
+	if doer.elementsCreated != 1 {
+		t.Errorf("expected 1 element created via fallback, got %d", doer.elementsCreated)
+	}
+}

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -504,7 +504,8 @@ var dashboardImportCmd = &cobra.Command{
 					activeLayoutID = *layoutObj.Id
 					if lm, ok := lv.(map[string]interface{}); ok {
 						if componentsVal, ok := lm["dashboard_layout_components"].([]interface{}); ok {
-							for _, cv := range componentsVal {
+							matchedElems := make(map[int]bool)
+							for cIdx, cv := range componentsVal {
 								cb, _ := json.Marshal(cv)
 								var wdlc v4.WriteDashboardLayoutComponent
 								_ = json.Unmarshal(cb, &wdlc)
@@ -513,15 +514,42 @@ var dashboardImportCmd = &cobra.Command{
 								var elemMap map[string]interface{}
 								if cm, ok := cv.(map[string]interface{}); ok {
 									matchIDStr := idToStr(cm["dashboard_element_id"])
-									if matchIDStr != "" {
-										if elementsVal, ok := m["dashboard_elements"].([]interface{}); ok {
-											for _, ev := range elementsVal {
+									compTitle, _ := cm["element_title"].(string)
+
+									if elementsVal, ok := m["dashboard_elements"].([]interface{}); ok {
+										if matchIDStr != "" {
+											for eIdx, ev := range elementsVal {
+												if matchedElems[eIdx] {
+													continue
+												}
 												if em, ok := ev.(map[string]interface{}); ok {
 													if idToStr(em["id"]) == matchIDStr {
 														elemMap = em
+														matchedElems[eIdx] = true
 														break
 													}
 												}
+											}
+										}
+										if elemMap == nil && compTitle != "" {
+											for eIdx, ev := range elementsVal {
+												if matchedElems[eIdx] {
+													continue
+												}
+												if em, ok := ev.(map[string]interface{}); ok {
+													elemTitle, _ := em["title"].(string)
+													if elemTitle != "" && elemTitle == compTitle {
+														elemMap = em
+														matchedElems[eIdx] = true
+														break
+													}
+												}
+											}
+										}
+										if elemMap == nil && cIdx < len(elementsVal) && !matchedElems[cIdx] {
+											if em, ok := elementsVal[cIdx].(map[string]interface{}); ok {
+												elemMap = em
+												matchedElems[cIdx] = true
 											}
 										}
 									}
@@ -533,24 +561,42 @@ var dashboardImportCmd = &cobra.Command{
 									_ = json.Unmarshal(eb, &wde)
 									wde.DashboardId = &resID
 
+									wde.ResultMakerId = nil
+									wde.ResultMaker = nil
+									wde.LookId = nil
+									wde.QueryId = nil
+									wde.MergeResultId = nil
+
 									if lookVal, ok := elemMap["look"].(map[string]interface{}); ok {
-										lID, _ := UpsertLookHelper(c, folderID, myID, lookVal, dashboardImportForce)
-										wde.LookId = &lID
+										if qMap, ok := lookVal["query"].(map[string]interface{}); ok {
+											delete(qMap, "client_id")
+										}
+										lID, err := UpsertLookHelper(c, folderID, myID, lookVal, dashboardImportForce)
+										if err == nil && lID != "" {
+											wde.LookId = &lID
+										} else if err != nil {
+											fmt.Fprintf(os.Stderr, "UpsertLookHelper failed: %v\n", err)
+										}
 									} else if qVal, ok := elemMap["query"].(map[string]interface{}); ok {
 										qb, _ := json.Marshal(qVal)
 										var wq v4.WriteQuery
 										_ = json.Unmarshal(qb, &wq)
-										cq, _ := c.SDK.CreateQuery(wq, "", nil)
-										if cq.Id != nil {
+										wq.ClientId = nil
+										cq, err := c.SDK.CreateQuery(wq, "", nil)
+										if err == nil && cq.Id != nil {
 											wde.QueryId = cq.Id
+										} else if err != nil {
+											fmt.Fprintf(os.Stderr, "CreateQuery failed: %v\n", err)
 										}
 									} else if mVal, ok := elemMap["merge_result"].(map[string]interface{}); ok {
 										mb, _ := json.Marshal(mVal)
 										var wmq v4.WriteMergeQuery
 										_ = json.Unmarshal(mb, &wmq)
-										cmq, _ := c.SDK.CreateMergeQuery(wmq, "", nil)
-										if cmq.Id != nil {
+										cmq, err := c.SDK.CreateMergeQuery(wmq, "", nil)
+										if err == nil && cmq.Id != nil {
 											wde.MergeResultId = cmq.Id
+										} else if err != nil {
+											fmt.Fprintf(os.Stderr, "CreateMergeQuery failed: %v\n", err)
 										}
 									}
 
@@ -578,6 +624,8 @@ var dashboardImportCmd = &cobra.Command{
 												break
 											}
 										}
+									} else if err != nil {
+										fmt.Fprintf(os.Stderr, "CreateDashboardElement failed: %v\n", err)
 									}
 								}
 							}

--- a/internal/cmd/look.go
+++ b/internal/cmd/look.go
@@ -242,6 +242,7 @@ var lookImportCmd = &cobra.Command{
 		qb, _ := json.Marshal(qVal)
 		var wq v4.WriteQuery
 		_ = json.Unmarshal(qb, &wq)
+		wq.ClientId = nil
 		createdQuery, err := c.SDK.CreateQuery(wq, "", nil)
 		if err != nil || createdQuery.Id == nil {
 			return fmt.Errorf("failed to create query: %v", err)
@@ -347,6 +348,7 @@ func UpsertLookHelper(c *client.ClientWrapper, folderID, myID string, m map[stri
 	qb, _ := json.Marshal(qVal)
 	var wq v4.WriteQuery
 	_ = json.Unmarshal(qb, &wq)
+	wq.ClientId = nil
 	createdQuery, err := c.SDK.CreateQuery(wq, "", nil)
 	if err != nil || createdQuery.Id == nil {
 		return "", fmt.Errorf("failed to create query: %v", err)


### PR DESCRIPTION
Conflicting Result Maker vs. Query/Look IDs: Exported element definitions often included legacy values for query_id, look_id, or result_maker_id. Looker API rejects CreateDashboardElement requests (with status 422) if a result_maker_id is passed alongside query_id/look_id, or if an invalid/legacy ID from another server is provided.

Conflicting Client IDs (already_exists): When creating underlying queries via CreateQuery, the exported query definitions included legacy client_id fields ("client_id": "ODhj2Z..."). If that client_id is already registered on the server, Looker rejects the query creation with client_id already in use by another query.